### PR TITLE
Parameter for build script to allow building for other than Linux

### DIFF
--- a/build
+++ b/build
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+# check whether build architecture specified, otherwise default to linux
+GOOS="linux"
+if [ -n "$1" ]; then
+  GOOS="$1"
+fi
+
+echo "Building bin/server for $GOOS"
+
 # allow builds outside the standard GOPATH via symlink
 export GOPATH=${PWD}/Godeps/_workspace
 export GOBIN=${PWD}/bin
@@ -8,4 +16,5 @@ mkdir -p $GOPATH/src/github.com/coreos
 # directory or symlink must be present
 [ -d $GOPATH/src/github.com/coreos/coreos-baremetal ] || ln -s ${PWD} $GOPATH/src/github.com/coreos/coreos-baremetal
 
-CGO_ENABLED=0 GOOS=linux go build -o bin/server -a -tags netgo -ldflags '-w' github.com/coreos/coreos-baremetal/cmd/bootcfg
+CGO_ENABLED=0 GOOS=$GOOS go build -o bin/server.$GOOS -a -tags netgo -ldflags '-w' github.com/coreos/coreos-baremetal/cmd/bootcfg
+ln -sf server.$GOOS bin/server


### PR DESCRIPTION
builds binary as `server.<architecture>` e.g. `server.linux`, `server.darwin`
creates symlink from `server` to the last built binary