### PR TITLE
Support a machines/default directory, for first time boot of new server

### DIFF
--- a/api/spec.go
+++ b/api/spec.go
@@ -39,11 +39,15 @@ func (r *specResource) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 // getMatchingSpec returns the Spec matching the given attributes.
+// If no matching Spec found, and a Spec called "default" exists, returns that Spec.
 func getMatchingSpec(store Store, attrs MachineAttrs) (*Spec, error) {
 	if machine, err := store.Machine(attrs.UUID); err == nil && machine.Spec != nil {
 		return machine.Spec, nil
 	}
 	if machine, err := store.Machine(attrs.MAC.String()); err == nil && machine.Spec != nil {
+		return machine.Spec, nil
+	}
+	if machine, err := store.Machine("default"); err == nil && machine.Spec != nil {
 		return machine.Spec, nil
 	}
 	return nil, fmt.Errorf("no spec matching %v", attrs)


### PR DESCRIPTION
The API server returns the Spec for machine "default" if it can't find a specific Spec for that machine.

```
data/
  machines/
    52:54:00:20:17:f9/
      machine.json
    default/
      machine.json
```

This allows me to boot new servers for the first time using a default configuration, and discover their MAC address so I can create a specific configuration.