### PR TITLE
api: Allow default machine Spec selector

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -15,7 +15,7 @@ Serves a static iPXE boot script which gathers client machine attributes and cha
 
 ## iPXE
 
-Finds the spec matching the attribute query parameters and renders the boot config as an iPXE script. Attributes are matched in priority order (UUID, MAC).
+Finds the spec matching the attribute query parameters and renders the boot config as an iPXE script. Attributes are matched in priority order (UUID, MAC, default).
 
     GET http://bootcfg.example.com/ipxe
 
@@ -60,7 +60,7 @@ Finds the spec matching the attribute query parameters and renders the boot conf
 
 ## Cloud Config
 
-Finds the spec matching the attribute query parameters and returns the corresponding cloud config file. Attributes are matched in priority order (UUID, MAC).
+Finds the spec matching the attribute query parameters and returns the corresponding cloud config file. Attributes are matched in priority order (UUID, MAC, default).
 
     GET http://bootcfg.example.com/cloud
 
@@ -83,7 +83,7 @@ Finds the spec matching the attribute query parameters and returns the correspon
 
 ## Ignition Config
 
-Finds the spec matching the attribute query parameters and returns the corresponding ignition config JSON. Attributes are matched in priority order (UUID, MAC).
+Finds the spec matching the attribute query parameters and returns the corresponding ignition config JSON. Attributes are matched in priority order (UUID, MAC, default).
 
     GET http://bootcfg.example.com/ignition
 

--- a/Documentation/bootcfg.md
+++ b/Documentation/bootcfg.md
@@ -50,7 +50,7 @@ Map container port 8080 to host port 8080 to quickly check endpoints:
 
 A `Store` maintains `Machine`, `Spec`, and ignition/cloud config resources. By default, `bootcfg` uses a `FileStore` to search a filesystem data directory for these resources.
 
-Prepare a data directory or modify the example [data](../data) provided. The `FileStore` expects `Machine` JSON files to be located at `machines/:id/machine.json` where the id can be a UUID or MAC address. `Spec` JSON files should be located at `specs/:id/spec.json` with any unique spec identifier.
+Prepare a data directory or modify the example [data](../data) provided. The `FileStore` expects `Machine` JSON files to be located at `machines/:id/machine.json` where the id can be a UUID or MAC address or "default". `Spec` JSON files should be located at `specs/:id/spec.json` with any unique spec identifier.
 
 You may wish to keep the data directory under version control with your other infrastructure configs, since it contains the declarative configuration of your hardware.
 
@@ -67,6 +67,8 @@ Ignition configs and cloud configs can be named whatever you like and dropped in
      │   │   └── machine.json
      │   ├── 2d9354a2-e8db-4021-bff5-20ffdf443d6f
      │   │   └── machine.json
+     │   └── default
+     │       └── machine.json
      └── specs
          └── orion
              └── spec.json

--- a/api/machine_test.go
+++ b/api/machine_test.go
@@ -10,15 +10,15 @@ import (
 )
 
 var (
-	// testMachine specifies its Spec.
+	validMACStr = "52:54:00:89:d8:10"
+	// testMachine embeds its Spec.
 	testMachine = &Machine{
 		ID:   "a1b2c3d4",
 		Spec: testSpec,
 	}
-	// testSharedSpecMachine references a Spec.
-	testSharedSpecMachine = &Machine{
-		ID:     "a1b2c3d4",
-		SpecID: "g1h2i3j4",
+	testMachineEmptySpec = &Machine{
+		ID:   "a1b2c3d4",
+		Spec: emptySpec,
 	}
 	expectedMachineJSON = `{"id":"a1b2c3d4","spec":{"id":"g1h2i3j4","boot":{"kernel":"/image/kernel","initrd":["/image/initrd_a","/image/initrd_b"],"cmdline":{"a":"b","c":""}},"cloud_id":"cloud-config.yml","ignition_id":"ignition.json"},"spec_id":""}`
 )
@@ -48,7 +48,7 @@ func TestMachineHandler_MissingConfig(t *testing.T) {
 }
 
 func TestAttrsFromRequest(t *testing.T) {
-	hwAddr, err := net.ParseMAC("52:54:00:89:d8:10")
+	hwAddr, err := net.ParseMAC(validMACStr)
 	assert.Nil(t, err)
 	cases := []struct {
 		urlString string

--- a/api/pixiecore_test.go
+++ b/api/pixiecore_test.go
@@ -8,14 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var validMAC = "52:54:00:89:d8:10"
-
 func TestPixiecoreHandler(t *testing.T) {
 	store := &fixedStore{
-		Machines: map[string]*Machine{validMAC: testMachine},
+		Machines: map[string]*Machine{validMACStr: testMachine},
 	}
 	h := pixiecoreHandler(store)
-	req, _ := http.NewRequest("GET", "/"+validMAC, nil)
+	req, _ := http.NewRequest("GET", "/"+validMACStr, nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	// assert that:
@@ -39,7 +37,7 @@ func TestPixiecoreHandler_InvalidMACAddress(t *testing.T) {
 func TestPixiecoreHandler_NoMatchingSpec(t *testing.T) {
 	store := &emptyStore{}
 	h := pixiecoreHandler(store)
-	req, _ := http.NewRequest("GET", "/"+validMAC, nil)
+	req, _ := http.NewRequest("GET", "/"+validMACStr, nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)

--- a/api/spec.go
+++ b/api/spec.go
@@ -40,12 +40,16 @@ func (r *specResource) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	renderJSON(w, spec)
 }
 
-// getMatchingSpec returns the Spec matching the given attributes.
+// getMatchingSpec returns the Spec matching the given attributes. Attributes
+// are matched in priority order (UUID, MAC, default).
 func getMatchingSpec(store Store, attrs MachineAttrs) (*Spec, error) {
 	if machine, err := store.Machine(attrs.UUID); err == nil && machine.Spec != nil {
 		return machine.Spec, nil
 	}
 	if machine, err := store.Machine(attrs.MAC.String()); err == nil && machine.Spec != nil {
+		return machine.Spec, nil
+	}
+	if machine, err := store.Machine("default"); err == nil && machine.Spec != nil {
 		return machine.Spec, nil
 	}
 	return nil, fmt.Errorf("no spec matching %v", attrs)

--- a/api/spec_test.go
+++ b/api/spec_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,6 +23,9 @@ var (
 		},
 		CloudConfig:    "cloud-config.yml",
 		IgnitionConfig: "ignition.json",
+	}
+	emptySpec = &Spec{
+		ID: "empty",
 	}
 	expectedSpecJSON = `{"id":"g1h2i3j4","boot":{"kernel":"/image/kernel","initrd":["/image/initrd_a","/image/initrd_b"],"cmdline":{"a":"b","c":""}},"cloud_id":"cloud-config.yml","ignition_id":"ignition.json"}`
 )
@@ -48,4 +52,59 @@ func TestSpecHandler_MissingConfig(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetMatchingSpec_ByUUID(t *testing.T) {
+	hwAddr, err := net.ParseMAC(validMACStr)
+	assert.Nil(t, err)
+	store := &fixedStore{
+		Machines: map[string]*Machine{
+			"a1b2c3d4":      testMachine,
+			hwAddr.String(): testMachineEmptySpec,
+		},
+		Specs: map[string]*Spec{"g1h2i3j4": testSpec},
+	}
+	spec, err := getMatchingSpec(store, MachineAttrs{UUID: "a1b2c3d4", MAC: hwAddr})
+	// assert that:
+	// - attributes match the testMachine's Spec
+	// - UUID attribute takes priority over MAC address
+	assert.Nil(t, err)
+	assert.Equal(t, testSpec, spec)
+}
+
+func TestGetMatchingSpec_ByMAC(t *testing.T) {
+	hwAddr, err := net.ParseMAC(validMACStr)
+	assert.Nil(t, err)
+	store := &fixedStore{
+		Machines: map[string]*Machine{
+			hwAddr.String(): testMachine,
+			"default":       testMachineEmptySpec,
+		},
+		Specs: map[string]*Spec{"g1h2i3j4": testSpec},
+	}
+	spec, err := getMatchingSpec(store, MachineAttrs{MAC: hwAddr})
+	// assert that:
+	// - attributes match the testMachine's Spec
+	// - MAC address attribute takes priority over default
+	assert.Nil(t, err)
+	assert.Equal(t, testSpec, spec)
+}
+
+func TestGetMatchingSpec_Default(t *testing.T) {
+	store := &fixedStore{
+		Machines: map[string]*Machine{"default": testMachine},
+		Specs:    map[string]*Spec{"g1h2i3j4": testSpec},
+	}
+	spec, err := getMatchingSpec(store, MachineAttrs{UUID: "any-uuid"})
+	assert.Nil(t, err)
+	assert.Equal(t, testSpec, spec)
+}
+
+func TestGetMatchingSpec_NoMatchingSpec(t *testing.T) {
+	store := &emptyStore{}
+	spec, err := getMatchingSpec(store, MachineAttrs{})
+	assert.Nil(t, spec)
+	if assert.Error(t, err) {
+		assert.Equal(t, err.Error(), "no spec matching { }")
+	}
 }

--- a/data/machines/52:54:00:20:17:f9/machine.json
+++ b/data/machines/52:54:00:20:17:f9/machine.json
@@ -1,15 +1,4 @@
 {
     "id": "52:54:00:20:17:f9",
-    "spec": {
-      "boot": {
-          "kernel": "/images/coreos/877.1.0/coreos_production_pxe.vmlinuz",
-          "initrd": ["/images/coreos/877.1.0/coreos_production_pxe_image.cpio.gz"],
-          "cmdline": {
-              "cloud-config-url": "http://172.17.0.2:8080/cloud?mac=52:54:00:20:17:f9",
-              "coreos.autologin": ""
-          }
-      },
-      "cloud_id": "node1-cloud.yml"
-    },
-    "spec_id": ""
+    "spec_id": "orion"
 }

--- a/data/machines/default/machine.json
+++ b/data/machines/default/machine.json
@@ -1,0 +1,4 @@
+{
+  "id": "default",
+  "spec_id": "orion"
+}

--- a/data/specs/orion/spec.json
+++ b/data/specs/orion/spec.json
@@ -11,5 +11,5 @@
         }
     },
     "cloud_id": "orion-cloud-config.yml",
-    "ignition_id": "hello-ignition.json"
+    "ignition_id": "node2.json"
 }


### PR DESCRIPTION
* If `data/machines/default/machine.json` exists, apply the Spec it
defines or references to all machines not matched by UUID or MAC