### PR TITLE
Rename -images-path to -assets-path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 data/
 Godeps/
-images/
+assets/
 vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ _testmain.go
 bin/
 coverage/
 Godeps/_workspace/src/github.com/coreos/coreos-baremetal
-images/
+assets/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Latest
 
+* Renamed flag `-images-path` to `-assets-path`
+* Renamed endpoint `/images` to `/assets`
+
 ## v0.1.0 (2015-01-08)
 
 Initial release of the coreos-baremetal Config Service.

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -29,8 +29,8 @@ Finds the spec matching the attribute query parameters and renders the boot conf
 **Response**
 
     #!ipxe
-    kernel /images/coreos/835.9.0/coreos_production_pxe.vmlinuz cloud-config-url=http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.autologin
-    initrd  /images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz
+    kernel /assets/coreos/835.9.0/coreos_production_pxe.vmlinuz cloud-config-url=http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.autologin
+    initrd  /assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz
     boot
 
 The kernel, cmdline kernel options, and initrd are populated from a `Spec`.
@@ -50,8 +50,8 @@ Finds the spec matching the attribute query parameters and renders the boot conf
 **Response**
 
     {
-      "kernel":"/images/coreos/877.1.0/coreos_production_pxe.vmlinuz",
-      "initrd":["/images/coreos/877.1.0/coreos_production_pxe_image.cpio.gz"],
+      "kernel":"/assets/coreos/877.1.0/coreos_production_pxe.vmlinuz",
+      "initrd":["/assets/coreos/877.1.0/coreos_production_pxe_image.cpio.gz"],
       "cmdline":{
         "cloud-config-url":"http://bootcfg.example.com/cloud",
         "coreos.autologin":""
@@ -133,9 +133,9 @@ Get a `Spec` definition by id (UUID, MAC).
 {
   "id": "orion",
   "boot": {
-    "kernel": "\/images\/coreos\/835.9.0\/coreos_production_pxe.vmlinuz",
+    "kernel": "\/assets\/coreos\/835.9.0\/coreos_production_pxe.vmlinuz",
     "initrd": [
-      "\/images\/coreos\/835.9.0\/coreos_production_pxe_image.cpio.gz"
+      "\/assets\/coreos\/835.9.0\/coreos_production_pxe_image.cpio.gz"
     ],
     "cmdline": {
       "cloud-config-url": "http:\/\/172.17.0.2:8080\/cloud?uuid=${uuid}&mac=${net0\/mac:hexhyp}",
@@ -146,11 +146,11 @@ Get a `Spec` definition by id (UUID, MAC).
 }
 ```
 
-## Image Assets
+## Assets
 
-If you need to host kernel and initrd images within your network, bootcfg server's `/images/` route serves free-form static assets. Set the `-images-path` when starting the bootcfg server. Here is an example images directory layout:
+If you need to host static assets (e.g. kernel, initrd) within your network, bootcfg server's `/assets/` route serves free-form static assets. Set the `-assets-path` when starting the bootcfg server. Here is an example:
 
-    images/
+    assets/
     └── coreos
         └── 835.9.0
             ├── coreos_production_pxe.vmlinuz

--- a/Documentation/bootcfg.md
+++ b/Documentation/bootcfg.md
@@ -25,16 +25,16 @@ The latest image corresponds to the most recent `coreos-baremetal` master commit
 
 [Prepare a data volume](#data) with `Spec` and ignition/cloud configs. Optionally, prepare a volume of downloaded CoreOS kernel and initrd image assets that `bootcfg` should serve.
 
-    ./scripts/get-coreos   # download CoreOS 835.9.0 to images/coreos/835.9.0
+    ./scripts/get-coreos               # download CoreOS 835.9.0
     ./scripts/get-coreos beta 877.1.0
 
-Run the container and mount the data and images directories as volumes.
+Run the container and mount the data and assets directories as volumes.
 
-    docker run -p 8080:8080 --name=bootcfg --rm -v $PWD/examples/dev:/data:Z -v $PWD/images:/images:Z coreos/bootcfg -address=0.0.0.0:8080 [-log-level=debug]
+    docker run -p 8080:8080 --name=bootcfg --rm -v $PWD/examples/dev:/data:Z -v $PWD/assets:/assets:Z coreos/bootcfg -address=0.0.0.0:8080 [-log-level=debug]
 
 ## Endpoints
 
-The [API](api.md) documents the iPXE and Pixiecore endpoints, the cloud config endpoint, and image assets.
+The [API](api.md) documents the iPXE and Pixiecore endpoints, the cloud config endpoint, and assets.
 
 Map container port 8080 to host port 8080 to quickly check endpoints:
 
@@ -43,7 +43,7 @@ Map container port 8080 to host port 8080 to quickly check endpoints:
 * Cloud Config: `/cloud?uuid=val`
 * Ignition Config: `/ignition?uuid=val`
 * Spec: `/spec/:id`
-* Images: `/images`
+* Assets: `/assets`
 
 ## Data
 
@@ -116,8 +116,8 @@ Boot config files contain JSON referencing a kernel image, init RAM fileystems, 
     {
         "id": "etcd2",
         "boot": {
-            "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-            "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+            "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+            "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
             "cmdline": {
                 "cloud-config-url": "http://bootcfg.foo/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
                 "coreos.autologin": "",
@@ -129,7 +129,7 @@ Boot config files contain JSON referencing a kernel image, init RAM fileystems, 
         "ignition_id": "node2.json"
     }
 
-The `"boot"` section references the kernel image, init RAM filesystem, and kernel options to use. Point kernel and initrd to remote images or to local [image assets](#images).
+The `"boot"` section references the kernel image, init RAM filesystem, and kernel options to use. Point kernel and initrd to remote images or to local [assets](#assets).
 
 To use cloud-init, set the `cloud-config-url` kernel option to the `bootcfg` cloud endpoint to reference the cloud config named by `cloud_id`.
 
@@ -175,22 +175,22 @@ Ignition is a configuration system for provisioning CoreOS instances before user
 
 See the Ignition [docs](https://coreos.com/ignition/docs/latest/) and [github](https://github.com/coreos/ignition) for the latest details.
 
-## Images
+## Assets
 
-Optionally, `bootcfg` can host free-form static assets if an `-images-path` argument to a directory is provided. This is a quick way to serve kernel and init RAM filesystem images, GPG verify them at an origin, and lets client machines download images without using egress bandwidth.
+Optionally, `bootcfg` can host free-form static assets if an `-assets-path` argument to a directory is provided. This is a quick way to serve kernel and initrd assets and reduce bandwidth usage.
 
-    images/
+    assets/
     └── coreos
         └── 835.9.0
             ├── coreos_production_pxe.vmlinuz
             └── coreos_production_pxe_image.cpio.gz
 
-Run the `get-coreos` script to quickly download kernel and initrd images from a recent CoreOS release into an `/images` directory.
+Run the `get-coreos` script to quickly download kernel and initrd image assets.
 
     ./scripts/get-coreos                 # stable, 835.9.0
     ./scripts/get-coreos beta 877.1.0
 
-To reference these local images, change the `kernel` and `initrd` in a boot config file. For example, change `http://stable.release.core-os.net/amd64-usr/current/coreos_production_pxe.vmlinuz` to `/images/coreos/835.9.0/coreos_production_pxe.vmlinuz`.
+To reference local assets, change the `kernel` and `initrd` in a boot config file. For example, change `http://stable.release.core-os.net/amd64-usr/current/coreos_production_pxe.vmlinuz` to `/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz`.
 
 ## Virtual and Physical Machine Guides
 

--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -8,16 +8,16 @@
 | -address | BOOTCFG_ADDRESS | 0.0.0.0:8080 |
 | -config | BOOTCFG_CONFIG | ./data/config.yaml |
 | -data-path | BOOTCFG_DATA_PATH | ./data |
-| -images-path | BOOTCFG_IMAGES_PATH | ./images, ./static |
+| -assets-path | BOOTCFG_ASSETS_PATH | ./assets |
 | -log-level | BOOTCFG_LOG_LEVEL | critical, error, warning, notice, info, debug |
 
 ## Examples
 
 Binary
 
-    ./run -address=0.0.0.0:8080 -data-path=./examples/dev -config=./examples/dev/config.yaml -images-path=./images -log-level=debug
+    ./run -address=0.0.0.0:8080 -data-path=./examples/dev -config=./examples/dev/config.yaml -assets-path=./assets -log-level=debug
 
 Container
 
-    docker run -p 8080:8080 --name=bootcfg --rm -v $PWD/examples/dev:/data:Z -v $PWD/images:/images:Z coreos/bootcfg:latest -address=0.0.0.0:8080 -data-path=./data -config=./data/config.yaml -images-path=./images -log-level=debug
+    docker run -p 8080:8080 --name=bootcfg --rm -v $PWD/examples/dev:/data:Z -v $PWD/assets:/assets:Z coreos/bootcfg:latest -address=0.0.0.0:8080 -data-path=./data -config=./data/config.yaml -assets-path=./assets -log-level=debug
 

--- a/Documentation/physical-hardware.md
+++ b/Documentation/physical-hardware.md
@@ -21,7 +21,7 @@ Set up `coreos/bootcfg` according to the [docs](bootcfg.md). Pull the `coreos/bo
 
 Run the `bootcfg` container to serve configs for any of the network environments we'll discuss next.
 
-    docker run -p 8080:8080 --net=host --name=bootcfg --rm -v $PWD/examples/dev:/data:Z -v $PWD/images:/images:Z coreos/bootcfg:latest -address=0.0.0.0:8080 [-log-level=debug]
+    docker run -p 8080:8080 --net=host --name=bootcfg --rm -v $PWD/examples/dev:/data:Z -v $PWD/assets:/assets:Z coreos/bootcfg:latest -address=0.0.0.0:8080 [-log-level=debug]
 
 Note, the kernel options in the `Spec` [examples](../examples) reference 172.17.0.2 (the libvirt case). Your kernel cmdline options should reference the IP or DNS name where `bootcfg` runs.
 

--- a/Documentation/virtual-hardware.md
+++ b/Documentation/virtual-hardware.md
@@ -14,7 +14,7 @@ Set up `coreos/bootcfg` according to the [docs](bootcfg.md). Pull the `coreos/bo
 
 Run the `bootcfg` container to serve configs for any of the network environments we'll discuss next.
 
-    docker run -p 8080:8080 --name=bootcfg --rm -v $PWD/examples/dev:/data:Z -v $PWD/images:/images:Z coreos/bootcfg:latest -address=0.0.0.0:8080 -log-level=debug
+    docker run -p 8080:8080 --name=bootcfg --rm -v $PWD/examples/dev:/data:Z -v $PWD/assets:/assets:Z coreos/bootcfg:latest -address=0.0.0.0:8080 -log-level=debug
 
 Note, the kernel options in the `Spec` [examples](../examples) reference 172.17.0.2, the first container IP Docker is likely to assign to `bootcfg`. Ensure your kernel options point to where `bootcfg` runs.
 

--- a/api/server.go
+++ b/api/server.go
@@ -17,21 +17,21 @@ var log = capnslog.NewPackageLogger("github.com/coreos/coreos-baremetal", "api")
 type Config struct {
 	// Store for configs (boot, cloud)
 	Store Store
-	// Path to static image assets
-	ImagePath string
+	// Path to static assets
+	AssetsPath string
 }
 
 // Server serves boot and cloud configs for PXE-based clients.
 type Server struct {
-	store     Store
-	imagePath string
+	store      Store
+	assetsPath string
 }
 
 // NewServer returns a new Server.
 func NewServer(config *Config) *Server {
 	return &Server{
-		store:     config.Store,
-		imagePath: config.ImagePath,
+		store:      config.Store,
+		assetsPath: config.AssetsPath,
 	}
 }
 
@@ -52,7 +52,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	// API Resources
 	// specs
 	newSpecResource(mux, "/spec/", s.store)
-	// Kernel and Initrd Images
-	mux.Handle("/images/", http.StripPrefix("/images/", http.FileServer(http.Dir(s.imagePath))))
+	// kernel, initrd, and TLS assets
+	mux.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir(s.assetsPath))))
 	return mux
 }

--- a/cmd/bootcfg/main.go
+++ b/cmd/bootcfg/main.go
@@ -25,7 +25,7 @@ func main() {
 		address    string
 		configPath string
 		dataPath   string
-		imagesPath string
+		assetsPath string
 		logLevel   string
 		version    bool
 		help       bool
@@ -33,7 +33,7 @@ func main() {
 	flag.StringVar(&flags.address, "address", "127.0.0.1:8080", "HTTP listen address")
 	flag.StringVar(&flags.configPath, "config", "./data/config.yaml", "Path to config file")
 	flag.StringVar(&flags.dataPath, "data-path", "./data", "Path to data directory")
-	flag.StringVar(&flags.imagesPath, "images-path", "./images", "Path to static assets")
+	flag.StringVar(&flags.assetsPath, "assets-path", "./assets", "Path to static assets")
 	// available log levels https://godoc.org/github.com/coreos/pkg/capnslog#LogLevel
 	flag.StringVar(&flags.logLevel, "log-level", "info", "Set the logging level")
 	flag.BoolVar(&flags.version, "version", false, "print version and exit")
@@ -62,7 +62,7 @@ func main() {
 	if finfo, err := os.Stat(flags.dataPath); err != nil || !finfo.IsDir() {
 		log.Fatal("A path to a data directory is required")
 	}
-	if finfo, err := os.Stat(flags.imagesPath); err != nil || !finfo.IsDir() {
+	if finfo, err := os.Stat(flags.assetsPath); err != nil || !finfo.IsDir() {
 		log.Fatal("A path to an assets directory is required")
 	}
 
@@ -91,8 +91,8 @@ func main() {
 	}
 
 	config := &api.Config{
-		Store:     store,
-		ImagePath: flags.imagesPath,
+		Store:      store,
+		AssetsPath: flags.assetsPath,
 	}
 
 	// API server

--- a/examples/dev/specs/default/spec.json
+++ b/examples/dev/specs/default/spec.json
@@ -1,13 +1,13 @@
 {
-    "id": "default",
-    "boot": {
-        "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-        "cmdline": {
-            "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-            "coreos.autologin": ""
-        }
-    },
-    "cloud_id": "default.yaml",
-    "ignition_id": ""
+  "id": "default",
+  "boot": {
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": ""
+    }
+  },
+  "cloud_id": "default.yaml",
+  "ignition_id": ""
 }

--- a/examples/dev/specs/node1/spec.json
+++ b/examples/dev/specs/node1/spec.json
@@ -1,15 +1,15 @@
 {
   "id": "node1",
   "boot": {
-    "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-      "cmdline": {
-        "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-        "coreos.config.url": "http://172.17.0.2:8080/ignition?uuid=${uuid}",
-        "coreos.autologin": "",
-        "coreos.first_boot": ""
-      }
-    },
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url": "http://172.17.0.2:8080/ignition?uuid=${uuid}",
+      "coreos.autologin": "",
+      "coreos.first_boot": ""
+    }
+  },
   "cloud_id": "node1.yaml",
   "ignition_id": "node1.json"
 }

--- a/examples/dev/specs/node2/spec.json
+++ b/examples/dev/specs/node2/spec.json
@@ -1,15 +1,15 @@
 {
   "id": "node2",
   "boot": {
-    "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-      "cmdline": {
-        "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-        "coreos.config.url": "http://172.17.0.2:8080/ignition?uuid=${uuid}",
-        "coreos.autologin": "",
-        "coreos.first_boot": ""
-      }
-    },
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url": "http://172.17.0.2:8080/ignition?uuid=${uuid}",
+      "coreos.autologin": "",
+      "coreos.first_boot": ""
+    }
+  },
   "cloud_id": "node2.yaml",
   "ignition_id": "node2.json"
 }

--- a/examples/etcd-large/specs/etcd1/spec.json
+++ b/examples/etcd-large/specs/etcd1/spec.json
@@ -1,13 +1,13 @@
 {
-    "id": "etcd1",
-    "boot": {
-        "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-        "cmdline": {
-            "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-            "coreos.autologin": ""
-        }
-    },
-    "cloud_id": "etcd1.yaml",
-    "ignition_id": ""
+  "id": "etcd1",
+  "boot": {
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": ""
+    }
+  },
+  "cloud_id": "etcd1.yaml",
+  "ignition_id": ""
 }

--- a/examples/etcd-large/specs/etcd2/spec.json
+++ b/examples/etcd-large/specs/etcd2/spec.json
@@ -1,13 +1,13 @@
 {
-    "id": "etcd2",
-    "boot": {
-        "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-        "cmdline": {
-            "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-            "coreos.autologin": ""
-        }
-    },
-    "cloud_id": "etcd2.yaml",
-    "ignition_id": ""
+  "id": "etcd2",
+  "boot": {
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": ""
+    }
+  },
+  "cloud_id": "etcd2.yaml",
+  "ignition_id": ""
 }

--- a/examples/etcd-large/specs/etcd3/spec.json
+++ b/examples/etcd-large/specs/etcd3/spec.json
@@ -1,13 +1,13 @@
 {
-    "id": "etcd3",
-    "boot": {
-        "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-        "cmdline": {
-            "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-            "coreos.autologin": ""
-        }
-    },
-    "cloud_id": "etcd3.yaml",
-    "ignition_id": ""
+  "id": "etcd3",
+  "boot": {
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": ""
+    }
+  },
+  "cloud_id": "etcd3.yaml",
+  "ignition_id": ""
 }

--- a/examples/etcd-large/specs/worker/spec.json
+++ b/examples/etcd-large/specs/worker/spec.json
@@ -1,13 +1,13 @@
 {
-    "id": "worker",
-    "boot": {
-        "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-        "cmdline": {
-            "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-            "coreos.autologin": ""
-        }
-    },
-    "cloud_id": "worker.yaml",
-    "ignition_id": ""
+  "id": "worker",
+  "boot": {
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": ""
+    }
+  },
+  "cloud_id": "worker.yaml",
+  "ignition_id": ""
 }

--- a/examples/etcd-small/specs/etcd/spec.json
+++ b/examples/etcd-small/specs/etcd/spec.json
@@ -1,13 +1,13 @@
 {
-    "id": "etcd",
-    "boot": {
-        "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-        "cmdline": {
-            "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-            "coreos.autologin": ""
-        }
-    },
-    "cloud_id": "etcd.yaml",
-    "ignition_id": ""
+  "id": "etcd",
+  "boot": {
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": ""
+    }
+  },
+  "cloud_id": "etcd.yaml",
+  "ignition_id": ""
 }

--- a/examples/etcd-small/specs/worker/spec.json
+++ b/examples/etcd-small/specs/worker/spec.json
@@ -1,13 +1,13 @@
 {
-    "id": "worker",
-    "boot": {
-        "kernel": "/images/coreos/835.9.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/images/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
-        "cmdline": {
-            "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-            "coreos.autologin": ""
-        }
-    },
-    "cloud_id": "worker.yaml",
-    "ignition_id": ""
+  "id": "worker",
+  "boot": {
+    "kernel": "/assets/coreos/835.9.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": ""
+    }
+  },
+  "cloud_id": "worker.yaml",
+  "ignition_id": ""
 }

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -4,10 +4,14 @@
 
 CHANNEL=${1:-"stable"}
 VERSION=${2:-"835.9.0"}
-DEST=${PWD}/images/coreos/$VERSION
+DEST=${PWD}/assets/coreos/$VERSION
 
-mkdir -p $DEST
-echo "Downloading CoreOS kernel and initrd"
+echo "Downloading CoreOS kernel and initrd image assets"
+
+if [ ! -d "$DEST" ]; then
+  echo "Creating directory $DEST"
+  mkdir -p $DEST
+fi
 
 # kernel and sig
 BASE_URL=http://$CHANNEL.release.core-os.net/amd64-usr/$VERSION

--- a/scripts/pixiecore
+++ b/scripts/pixiecore
@@ -4,4 +4,4 @@ CONFIG_SERVICE=bootcfg
 CONFIG_SERVICE_IP=$(docker inspect --format {{.NetworkSettings.IPAddress}} ${CONFIG_SERVICE})
 CONFIG_SERVICE_PORT=$(docker inspect --format '{{ (index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort }}' ${CONFIG_SERVICE})
 
-docker run -v $PWD/images:/images:Z danderson/pixiecore -api http://$CONFIG_SERVICE_IP:$CONFIG_SERVICE_PORT/pixiecore
+docker run -v $PWD/assets:/assets:Z danderson/pixiecore -api http://$CONFIG_SERVICE_IP:$CONFIG_SERVICE_PORT/pixiecore


### PR DESCRIPTION
* Serve assets from /assets, remove /images endpoint
* Migrate images to assets so we have a place for general assets