### PR TITLE
build: don't force GOOS=linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
 MAINTAINER Dalton Hubble <dalton.hubble@coreos.com>
-COPY bin/server /server
+COPY bin/bootcfg /bootcfg
 EXPOSE 8080
-ENTRYPOINT ["./server"]
+ENTRYPOINT ["./bootcfg"]

--- a/build
+++ b/build
@@ -9,4 +9,4 @@ mkdir -p $GOPATH/src/github.com/coreos
 [ -d $GOPATH/src/github.com/coreos/coreos-baremetal ] || ln -s ${PWD} $GOPATH/src/github.com/coreos/coreos-baremetal
 
 LD_FLAGS="-w -X main.version=$(./git-version)"
-CGO_ENABLED=0 GOOS=linux go build -o bin/server -ldflags "$LD_FLAGS" -a -tags netgo github.com/coreos/coreos-baremetal/cmd/bootcfg
+CGO_ENABLED=0 go build -o bin/bootcfg -ldflags "$LD_FLAGS" -a -tags netgo github.com/coreos/coreos-baremetal/cmd/bootcfg

--- a/docker-build
+++ b/docker-build
@@ -3,5 +3,6 @@
 REPO=coreos/bootcfg
 GIT_SHA=$(./git-version)
 
+GOOS=linux ./build
 docker build -q --rm=true -t $REPO:$GIT_SHA .
 docker tag -f $REPO:$GIT_SHA $REPO:latest


### PR DESCRIPTION
There is no reason to force this. Instead have the docker-build command
do it before it is built.

Also, use the actual package name: bootcfg. It confused me that bootcfg
was called server.