### PR TITLE
examples: Configure networkd with Ignition in etcd examples

### DIFF
--- a/examples/etcd-large/cloud/etcd1.yaml
+++ b/examples/etcd-large/cloud/etcd1.yaml
@@ -13,19 +13,3 @@ coreos:
       command: start
     - name: fleet.service
       command: start
-    - name: 00-ens3.network
-      runtime: true
-      content: |
-        [Match]
-        Name=ens3
-        [Network]
-        Address=172.17.0.21/16
-    - name: down-interfaces.service
-      command: start
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/ip link set ens3 down
-        ExecStart=/usr/bin/ip addr flush dev ens3
-    - name: systemd-networkd.service
-      command: restart

--- a/examples/etcd-large/cloud/etcd2.yaml
+++ b/examples/etcd-large/cloud/etcd2.yaml
@@ -13,19 +13,3 @@ coreos:
       command: start
     - name: fleet.service
       command: start
-    - name: 00-ens3.network
-      runtime: true
-      content: |
-        [Match]
-        Name=ens3
-        [Network]
-        Address=172.17.0.22/16
-    - name: down-interfaces.service
-      command: start
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/ip link set ens3 down
-        ExecStart=/usr/bin/ip addr flush dev ens3
-    - name: systemd-networkd.service
-      command: restart

--- a/examples/etcd-large/cloud/etcd3.yaml
+++ b/examples/etcd-large/cloud/etcd3.yaml
@@ -13,19 +13,3 @@ coreos:
       command: start
     - name: fleet.service
       command: start
-    - name: 00-ens3.network
-      runtime: true
-      content: |
-        [Match]
-        Name=ens3
-        [Network]
-        Address=172.17.0.23/16
-    - name: down-interfaces.service
-      command: start
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/ip link set ens3 down
-        ExecStart=/usr/bin/ip addr flush dev ens3
-    - name: systemd-networkd.service
-      command: restart

--- a/examples/etcd-large/ignition/etcd1.json
+++ b/examples/etcd-large/ignition/etcd1.json
@@ -1,0 +1,11 @@
+{
+  "ignitionVersion": 1,
+  "networkd": {
+    "units": [
+      {
+        "name": "00-ens3.network",
+        "contents": "[Match]\nName=ens3\n\n[Network]\nDNS=8.8.8.8\nGateway=172.17.0.1\nAddress=172.17.0.21"
+      }
+    ]
+  }
+}

--- a/examples/etcd-large/ignition/etcd2.json
+++ b/examples/etcd-large/ignition/etcd2.json
@@ -1,0 +1,11 @@
+{
+  "ignitionVersion": 1,
+  "networkd": {
+    "units": [
+      {
+        "name": "00-ens3.network",
+        "contents": "[Match]\nName=ens3\n\n[Network]\nDNS=8.8.8.8\nGateway=172.17.0.1\nAddress=172.17.0.22"
+      }
+    ]
+  }
+}

--- a/examples/etcd-large/ignition/etcd3.json
+++ b/examples/etcd-large/ignition/etcd3.json
@@ -1,0 +1,11 @@
+{
+  "ignitionVersion": 1,
+  "networkd": {
+    "units": [
+      {
+        "name": "00-ens3.network",
+        "contents": "[Match]\nName=ens3\n\n[Network]\nDNS=8.8.8.8\nGateway=172.17.0.1\nAddress=172.17.0.23"
+      }
+    ]
+  }
+}

--- a/examples/etcd-large/specs/etcd1/spec.json
+++ b/examples/etcd-large/specs/etcd1/spec.json
@@ -5,9 +5,11 @@
     "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-      "coreos.autologin": ""
+      "coreos.config.url": "http://172.17.0.2:8080/ignition?uuid=${uuid}",
+      "coreos.autologin": "",
+      "coreos.first_boot": ""
     }
   },
   "cloud_id": "etcd1.yaml",
-  "ignition_id": ""
+  "ignition_id": "etcd1.json"
 }

--- a/examples/etcd-large/specs/etcd2/spec.json
+++ b/examples/etcd-large/specs/etcd2/spec.json
@@ -5,9 +5,11 @@
     "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-      "coreos.autologin": ""
+      "coreos.config.url": "http://172.17.0.2:8080/ignition?uuid=${uuid}",
+      "coreos.autologin": "",
+      "coreos.first_boot": ""
     }
   },
   "cloud_id": "etcd2.yaml",
-  "ignition_id": ""
+  "ignition_id": "etcd2.json"
 }

--- a/examples/etcd-large/specs/etcd3/spec.json
+++ b/examples/etcd-large/specs/etcd3/spec.json
@@ -5,9 +5,11 @@
     "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-      "coreos.autologin": ""
+      "coreos.config.url": "http://172.17.0.2:8080/ignition?uuid=${uuid}",
+      "coreos.autologin": "",
+      "coreos.first_boot": ""
     }
   },
   "cloud_id": "etcd3.yaml",
-  "ignition_id": ""
+  "ignition_id": "etcd3.json"
 }

--- a/examples/etcd-small/cloud/etcd.yaml
+++ b/examples/etcd-small/cloud/etcd.yaml
@@ -10,19 +10,3 @@ coreos:
   units:
     - name: etcd2.service
       command: start
-    - name: 00-ens3.network
-      runtime: true
-      content: |
-        [Match]
-        Name=ens3
-        [Network]
-        Address=172.17.0.21/16
-    - name: down-interfaces.service
-      command: start
-      content: |
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/ip link set ens3 down
-        ExecStart=/usr/bin/ip addr flush dev ens3
-    - name: systemd-networkd.service
-      command: restart

--- a/examples/etcd-small/ignition/etcd.json
+++ b/examples/etcd-small/ignition/etcd.json
@@ -1,0 +1,11 @@
+{
+  "ignitionVersion": 1,
+  "networkd": {
+    "units": [
+      {
+        "name": "00-ens3.network",
+        "contents": "[Match]\nName=ens3\n\n[Network]\nDNS=8.8.8.8\nGateway=172.17.0.1\nAddress=172.17.0.21"
+      }
+    ]
+  }
+}

--- a/examples/etcd-small/specs/etcd/spec.json
+++ b/examples/etcd-small/specs/etcd/spec.json
@@ -5,9 +5,11 @@
     "initrd": ["/assets/coreos/835.9.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "cloud-config-url": "http://172.17.0.2:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
-      "coreos.autologin": ""
+      "coreos.config.url": "http://172.17.0.2:8080/ignition?uuid=${uuid}",
+      "coreos.autologin": "",
+      "coreos.first_boot": ""
     }
   },
   "cloud_id": "etcd.yaml",
-  "ignition_id": ""
+  "ignition_id": "etcd.json"
 }


### PR DESCRIPTION
Favor configuring networkd before init rather than adding
networkd units in cloud config, marking the interface down,
and restarting networkd