### PR TITLE
dockerfiles: Fix entrypoints to be absolute paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine:latest
 MAINTAINER Dalton Hubble <dalton.hubble@coreos.com>
 COPY bin/bootcfg /bootcfg
 EXPOSE 8080
-ENTRYPOINT ["./bootcfg"]
+ENTRYPOINT ["/bootcfg"]

--- a/dockerfiles/dnsmasq/Dockerfile
+++ b/dockerfiles/dnsmasq/Dockerfile
@@ -5,4 +5,4 @@ RUN mkdir -p /var/lib/tftpboot
 RUN curl -s -o /var/lib/tftpboot/undionly.kpxe http://boot.ipxe.org/undionly.kpxe
 RUN ln -s /var/lib/tftpboot/undionly.kpxe /var/lib/tftpboot/undionly.kpxe.0
 EXPOSE 53
-ENTRYPOINT ["dnsmasq", "-d"]
+ENTRYPOINT ["/usr/sbin/dnsmasq", "-d"]


### PR DESCRIPTION
* Absolute entrypoints are expected for docker2aci