### PR TITLE
examples: Fix CNI metal0's destination routes

### DIFF
--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -34,7 +34,7 @@ sudo bash -c 'cat > /etc/rkt/net.d/20-metal.conf << EOF
   "ipam": {
     "type": "host-local",
     "subnet": "172.15.0.0/16",
-    "routes" : [ { "dst" : "172.15.0.0/16" } ]
+    "routes" : [ { "dst" : "0.0.0.0/0" } ]
    }
 }
 EOF'

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ These examples show declarative configurations for network booting libvirt VMs i
 | Name       | Description |  Reference     |
 |------------|-------------|----------------|
 | etcd | Cluster with 3 etcd nodes, 2 proxies | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
-|Kubernetes | Kubernetes cluster with 1 master, 1 worker, 1 dedicated etcd node | [reference](https://github.com/coreos/coreos-kubernetes) |
+| Kubernetes | Kubernetes cluster with 1 master, 1 worker, 1 dedicated etcd node | [reference](https://github.com/coreos/coreos-kubernetes) |
 | Disk Install | 2-stage Ignition: Install CoreOS, provision etcd cluster | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
 
 ## Experimental

--- a/examples/coreos-install.yaml
+++ b/examples/coreos-install.yaml
@@ -15,12 +15,12 @@ groups:
       os: installed
     metadata:
       networkd_name: ens3
-      networkd_gateway: 172.17.0.1
-      networkd_dns: 172.17.0.3
-      networkd_address: 172.17.0.21/16
-      ipv4_address: 172.17.0.21
+      networkd_gateway: 172.15.0.1
+      networkd_dns: 172.15.0.3
+      networkd_address: 172.15.0.21/16
+      ipv4_address: 172.15.0.21
       etcd_name: node1
-      etcd_initial_cluster: "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380"
+      etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
 
   - name: etcd Node 2
     spec: etcd
@@ -29,12 +29,12 @@ groups:
       os: installed
     metadata:
       networkd_name: ens3
-      networkd_gateway: 172.17.0.1
-      networkd_dns: 172.17.0.3
-      networkd_address: 172.17.0.22/16
-      ipv4_address: 172.17.0.22
+      networkd_gateway: 172.15.0.1
+      networkd_dns: 172.15.0.3
+      networkd_address: 172.15.0.22/16
+      ipv4_address: 172.15.0.22
       etcd_name: node2
-      etcd_initial_cluster: "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380"
+      etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
 
   - name: etcd Node 3
     spec: etcd
@@ -43,12 +43,12 @@ groups:
       os: installed
     metadata:
       networkd_name: ens3
-      networkd_gateway: 172.17.0.1
-      networkd_dns: 172.17.0.3
-      networkd_address: 172.17.0.23/16
-      ipv4_address: 172.17.0.23
+      networkd_gateway: 172.15.0.1
+      networkd_dns: 172.15.0.3
+      networkd_address: 172.15.0.23/16
+      ipv4_address: 172.15.0.23
       etcd_name: node3
-      etcd_initial_cluster: "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380"
+      etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
 
   - name: etcd Proxy
     spec: etcd_proxy
@@ -56,6 +56,6 @@ groups:
       os: installed
     metadata:
       networkd_name: ens3
-      networkd_gateway: 172.17.0.1
-      networkd_dns: 172.17.0.3
-      etcd_initial_cluster: "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380"
+      networkd_gateway: 172.15.0.1
+      networkd_dns: 172.15.0.3
+      etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"


### PR DESCRIPTION
* Supplied metal0 CNI definition restricted traffic destinations
to the metal0 bridge. Update to allow outbound traffic.
* Fixes the coreos-install example for use with rkt