### PR TITLE
examples: Show CoreOS install with Ignition support

### DIFF
--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -25,6 +25,7 @@ Create four VM nodes which have known hardware attributes. The nodes will be att
 Download the CoreOS PXE image assets to `assets/coreos`. The examples instruct machines to load these from the Config server, though you could change this.
 
     ./scripts/get-coreos
+    ./scripts/get-coreos channel version
 
 ## Containers
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -20,6 +20,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
 Download the CoreOS PXE image assets to `assets/coreos`. The examples instruct machines to load these from the Config server, though you could change this.
 
     ./scripts/get-coreos
+    ./scripts/get-coreos channel version
 
 Define the `metal0` virtual bridge with [CNI](https://github.com/appc/cni).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,11 +3,11 @@
 
 These examples show declarative configurations for network booting libvirt VMs into CoreOS clusters (Kubernetes, etcd) using `bootcfg`.
 
-| Name       | Description |  Reference     |
-|------------|-------------|----------------|
-| etcd | Cluster with 3 etcd nodes, 2 proxies | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
-| Kubernetes | Kubernetes cluster with 1 master, 1 worker, 1 dedicated etcd node | [reference](https://github.com/coreos/coreos-kubernetes) |
-| Disk Install | 2-stage Ignition: Install CoreOS, provision etcd cluster | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
+| Name       | Description |  Reference     | CoreOS Version |
+|------------|-------------|----------------|----------------|
+| etcd | Cluster with 3 etcd nodes, 2 proxies | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) | beta/899.6.0 |
+| Kubernetes | Kubernetes cluster with 1 master, 1 worker, 1 dedicated etcd node | [reference](https://github.com/coreos/coreos-kubernetes) | beta/899.6.0 |
+| etcd on disk | 2-stage Ignition: Install CoreOS, provision etcd cluster | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) | alpha/962.0.0,935.0.0 |
 
 ## Experimental
 
@@ -22,7 +22,7 @@ Get started running the `bootcfg` on your Linux machine to boot clusters of libv
 
 ## Physical Hardware
 
-Run the `bootcfg` to boot and configure physical machines (for testing). Update the network values in the `*.yaml` config to match your hardware and network. Generate TLS assets if required for the example (e.g. Kubernetes).
+Run `bootcfg` to boot and configure physical machines (for testing). Update the network values in the `*.yaml` config to match your hardware and network. Generate TLS assets if required for the example (e.g. Kubernetes).
 
 Continue to the [Physical Hardware Guide](../Documentation/physical-hardware.md) for details.
 

--- a/examples/coreos-install.yaml
+++ b/examples/coreos-install.yaml
@@ -21,6 +21,7 @@ groups:
       ipv4_address: 172.15.0.21
       etcd_name: node1
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
+      ssh_authorized_keys:
 
   - name: etcd Node 2
     spec: etcd

--- a/examples/ignition/coreos-install.yaml
+++ b/examples/ignition/coreos-install.yaml
@@ -10,10 +10,9 @@ systemd:
         After=network-online.target
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}}
+        ExecStart=/usr/bin/curl {{.ignition_endpoint}}?{{.query}}&os=installed -o ignition.json
+        ExecStart=/usr/bin/coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json
         ExecStart=/usr/bin/udevadm settle
-        ExecStart=/usr/bin/mount /dev/disk/by-label/OEM /mnt
-        ExecStart=/bin/sh -c 'echo set linux_append=\\"coreos.config.url=\"{{.ignition_endpoint}}?{{.query}}&os=installed\"\\" > /mnt/grub.cfg'
         ExecStart=/usr/bin/systemctl reboot
         [Install]
         WantedBy=multi-user.target

--- a/examples/specs/coreos-install/spec.json
+++ b/examples/specs/coreos-install/spec.json
@@ -1,8 +1,8 @@
 {
   "id": "coreos-install",
   "boot": {
-    "kernel": "/assets/coreos/899.6.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/899.6.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/962.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/962.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",


### PR DESCRIPTION
* Use the coreos-install -i option added in CoreOS alpha 949.0.0
* Download second stage Ignition config while in PXE first stage
* Resolves #46