### PR TITLE
travis: Add Go 1.6 to test matrix, change invalid MAC test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
   - docker
 go:
   - 1.5.3
+  - 1.6
   - tip
 env:
   global:

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -25,7 +25,7 @@ func TestLabelsFromRequest(t *testing.T) {
 		// parse and set MAC regardless of query argument case
 		{"http://a.io?UUID=a1b2c3&MAC=52:DA:00:89:d8:10", map[string]string{"UUID": "a1b2c3", "MAC": validMACStr}},
 		// ignore MAC addresses which do not parse
-		{"http://a.io?mac=?:?:?", emptyMap},
+		{"http://a.io?mac=x:x:x:x:x:x", emptyMap},
 	}
 	for _, c := range cases {
 		req, err := http.NewRequest("GET", c.urlString, nil)


### PR DESCRIPTION
* Test request could not be created due to a regression in `url.Parse` https://github.com/golang/go/issues/14573
* Update the example "bad" MAC address. It was a coincidence that the bad MAC ended in "?", using `x:x:x:x:x:x` tests the same handler behavior.