### PR TITLE
contrib/dnsmasq: Make coreos.com/dnsmasq:v0.2.0 rkt fetch-able

### DIFF
--- a/contrib/dnsmasq/README.md
+++ b/contrib/dnsmasq/README.md
@@ -9,9 +9,11 @@ The image bundles `undionly.kpxe` which chainloads PXE clients to iPXE and `grub
 
 ## Usage
 
-Build the ACI as described below. Run the ACI with [rkt](https://github.com/coreos/rkt).
+Run the `coreos.com/dnsmasq` ACI with rkt.
 
-    sudo rkt --insecure-options=image run dnsmasq.aci
+    sudo rkt trust --prefix coreos.com/dnsmasq
+    # gpg key fingerprint is: 18AD 5014 C99E F7E3 BA5F  6CE9 50BD D3E0 FC8A 365E
+    sudo rkt run coreos.com/dnsmasq:v0.2.0
 
 Press ^] three times to kill the container.
 

--- a/contrib/dnsmasq/build-aci
+++ b/contrib/dnsmasq/build-aci
@@ -13,7 +13,10 @@ acbuild --debug begin
 trap "{ export EXT=$?; acbuild --debug end && exit $EXT; }" EXIT
 
 # Name the ACI
-acbuild --debug set-name coreos/dnsmasq
+acbuild --debug set-name coreos.com/dnsmasq
+
+# Add a version label
+acbuild --debug label add version v0.2.0
 
 # Add alpine base dependency
 acbuild --debug dep add quay.io/coreos/alpine-sh


### PR DESCRIPTION
* ACI coreos.com/dnsmasq is available and signed by the CoreOS
Application Signing Key
* Resolves #69 