### PR TITLE
examples: Fix 2-stage install CoreOS and etcd_proxy setup

### DIFF
--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -92,7 +92,7 @@ Build the `dnsmasq.aci` ACI.
 
 Run `dnsmasq.aci`.
 
-    sudo rkt --insecure-options=image run dnsmasq.aci --net=metal0:IP=172.15.0.3 -- -d -q --dhcp-range=172.15.0.50,172.15.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:#ipxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://bootcfg.foo:8080/boot.ipxe --log-queries --log-dhcp --dhcp-option=3,172.15.0.1 --address=/bootcfg.foo/172.15.0.2
+    sudo rkt --insecure-options=image run dnsmasq.aci --dns=8.8.8.8 --net=metal0:IP=172.15.0.3 -- -d -q --dhcp-range=172.15.0.50,172.15.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:#ipxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://bootcfg.foo:8080/boot.ipxe --log-queries --log-dhcp --dhcp-option=3,172.15.0.1 --address=/bootcfg.foo/172.15.0.2
 
 In this case, dnsmasq runs a DHCP server allocating IPs to VMs between 172.15.0.50 and 172.15.0.99, resolves `bootcfg.foo` to 172.15.0.2 (the IP where `bootcfg` runs), and points iPXE clients to `http://bootcfg.foo:8080/boot.ipxe`.
 

--- a/examples/coreos-install.yaml
+++ b/examples/coreos-install.yaml
@@ -64,3 +64,4 @@ groups:
       networkd_dns: 172.15.0.3
       fleet_metadata: role=etcd-proxy
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
+      ssh_authorized_keys:

--- a/examples/coreos-install.yaml
+++ b/examples/coreos-install.yaml
@@ -19,6 +19,7 @@ groups:
       networkd_dns: 172.15.0.3
       networkd_address: 172.15.0.21/16
       ipv4_address: 172.15.0.21
+      fleet_metadata: "role=etcd,name=node1"
       etcd_name: node1
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
       ssh_authorized_keys:
@@ -34,6 +35,7 @@ groups:
       networkd_dns: 172.15.0.3
       networkd_address: 172.15.0.22/16
       ipv4_address: 172.15.0.22
+      fleet_metadata: "role=etcd,name=node2"
       etcd_name: node2
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
 
@@ -48,6 +50,7 @@ groups:
       networkd_dns: 172.15.0.3
       networkd_address: 172.15.0.23/16
       ipv4_address: 172.15.0.23
+      fleet_metadata: "role=etcd,name=node3"
       etcd_name: node3
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
 
@@ -59,4 +62,5 @@ groups:
       networkd_name: ens3
       networkd_gateway: 172.15.0.1
       networkd_dns: 172.15.0.3
+      fleet_metadata: role=etcd-proxy
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"

--- a/examples/etcd-docker.yaml
+++ b/examples/etcd-docker.yaml
@@ -11,6 +11,7 @@ groups:
       networkd_dns: 172.17.0.3
       networkd_address: 172.17.0.21/16
       ipv4_address: 172.17.0.21
+      fleet_metadata: "role=etcd,name=node1"
       etcd_name: node1
       etcd_initial_cluster: "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380"
 
@@ -24,6 +25,7 @@ groups:
       networkd_dns: 172.17.0.3
       networkd_address: 172.17.0.22/16
       ipv4_address: 172.17.0.22
+      fleet_metadata: "role=etcd,name=node2"
       etcd_name: node2
       etcd_initial_cluster: "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380"
 
@@ -37,6 +39,7 @@ groups:
       networkd_dns: 172.17.0.3
       networkd_address: 172.17.0.23/16
       ipv4_address: 172.17.0.23
+      fleet_metadata: "role=etcd,name=node3"
       etcd_name: node3
       etcd_initial_cluster: "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380"
 
@@ -46,4 +49,5 @@ groups:
       networkd_name: ens3
       networkd_gateway: 172.17.0.1
       networkd_dns: 172.17.0.3
+      fleet_metadata: role=etcd-proxy
       etcd_initial_cluster: "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380"

--- a/examples/etcd-rkt.yaml
+++ b/examples/etcd-rkt.yaml
@@ -11,6 +11,7 @@ groups:
       networkd_dns: 172.15.0.3
       networkd_address: 172.15.0.21/16
       ipv4_address: 172.15.0.21
+      fleet_metadata: "role=etcd,name=node1"
       etcd_name: node1
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
 
@@ -24,6 +25,7 @@ groups:
       networkd_dns: 172.15.0.3
       networkd_address: 172.15.0.22/16
       ipv4_address: 172.15.0.22
+      fleet_metadata: "role=etcd,name=node2"
       etcd_name: node2
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
 
@@ -37,6 +39,7 @@ groups:
       networkd_dns: 172.15.0.3
       networkd_address: 172.15.0.23/16
       ipv4_address: 172.15.0.23
+      fleet_metadata: "role=etcd,name=node3"
       etcd_name: node3
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
 
@@ -46,4 +49,5 @@ groups:
       networkd_name: ens3
       networkd_gateway: 172.15.0.1
       networkd_dns: 172.15.0.3
+      fleet_metadata: role=etcd-proxy
       etcd_initial_cluster: "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"

--- a/examples/ignition/etcd.yaml
+++ b/examples/ignition/etcd.yaml
@@ -14,6 +14,13 @@ systemd:
         ExecStart=/usr/bin/bash -c 'curl --url "http://bootcfg.foo:8080/metadata?{{.query}}" --retry 10 --output ${OUTPUT}'
         [Install]
         WantedBy=multi-user.target
+    - name: fleet.service
+      enable: true
+      dropins:
+        - name: fleet-metadata.conf
+          contents: |
+            [Service]
+            Environment="FLEET_METADATA={{.fleet_metadata}}"
     - name: etcd2.service
       enable: true
       dropins:
@@ -23,14 +30,15 @@ systemd:
             Requires=metadata.service
             After=metadata.service
             [Service]
+            # ETCD_NAME, ETCD_INITIAL_CLUSTER
             EnvironmentFile=/run/metadata/bootcfg
             ExecStart=
             ExecStart=/usr/bin/etcd2 \
               --advertise-client-urls=http://${IPV4_ADDRESS}:2379 \
               --initial-advertise-peer-urls=http://${IPV4_ADDRESS}:2380 \
               --listen-client-urls=http://0.0.0.0:2379 \
-              --listen-peer-urls=http://${IPV4_ADDRESS}:2380 \
-              --initial-cluster=${ETCD_INITIAL_CLUSTER}
+              --listen-peer-urls=http://${IPV4_ADDRESS}:2380
+
 networkd:
   units:
     - name: 00-{{.networkd_name}}.network

--- a/examples/ignition/etcd_proxy.yaml
+++ b/examples/ignition/etcd_proxy.yaml
@@ -14,6 +14,15 @@ systemd:
         ExecStart=/usr/bin/bash -c 'curl --url http://bootcfg.foo:8080/metadata --retry 10 --output ${OUTPUT}'
         [Install]
         WantedBy=multi-user.target
+    - name: fleet.service
+      enable: true
+      dropins:
+        - name: fleet-metadata.conf
+          contents: |
+            [Service]
+            # FLEET_METADATA
+            EnvironmentFile=/run/metadata/bootcfg
+            Environment="FLEET_ETCD_SERVERS=http://127.0.0.1:2379"
     - name: etcd2.service
       enable: true
       dropins:
@@ -23,12 +32,12 @@ systemd:
             Requires=metadata.service
             After=metadata.service
             [Service]
+            # ETCD_INITIAL_CLUSTER
             EnvironmentFile=/run/metadata/bootcfg
             ExecStart=
             ExecStart=/usr/bin/etcd2 \
               --proxy on
-              --listen-client-urls=http://localhost:2379 \
-              --initial-cluster=${ETCD_INITIAL_CLUSTER}
+              --listen-client-urls=http://127.0.0.1:2379
 
 {{ if .ssh_authorized_keys }}
 passwd:

--- a/examples/ignition/etcd_proxy.yaml
+++ b/examples/ignition/etcd_proxy.yaml
@@ -11,7 +11,7 @@ systemd:
         Type=oneshot
         Environment=OUTPUT=/run/metadata/bootcfg
         ExecStart=/usr/bin/mkdir --parent /run/metadata
-        ExecStart=/usr/bin/bash -c 'curl --url http://bootcfg.foo:8080/metadata --retry 10 --output ${OUTPUT}'
+        ExecStart=/usr/bin/bash -c 'curl --url "http://bootcfg.foo:8080/metadata?{{.query}}" --retry 10 --output ${OUTPUT}'
         [Install]
         WantedBy=multi-user.target
     - name: fleet.service

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -37,17 +37,17 @@ function usage {
 }
 
 function create_docker {
-  virt-install --name node1 -u 16e7d8a7-bfa9-428b-9117-363341bb330b --pxe --disk pool=default,size=4 --boot=hd,network --network=bridge:docker0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
-  virt-install --name node2 -u 264cd073-ca62-44b3-98c0-50aad5b5f819 --pxe --disk pool=default,size=4 --boot=hd,network --network=bridge:docker0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
-  virt-install --name node3 -u 39d2e747-2648-4d68-ae92-bbc70b245055 --pxe --disk pool=default,size=4 --boot=hd,network --network=bridge:docker0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
-  virt-install --name node4 -u 4ed46e8e-db69-471e-b874-0990dd65649d --pxe --disk pool=default,size=4 --boot=hd,network --network=bridge:docker0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+  virt-install --name node1 -u 16e7d8a7-bfa9-428b-9117-363341bb330b --pxe --disk pool=default,size=6 --boot=hd,network --network=bridge:docker0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+  virt-install --name node2 -u 264cd073-ca62-44b3-98c0-50aad5b5f819 --pxe --disk pool=default,size=6 --boot=hd,network --network=bridge:docker0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+  virt-install --name node3 -u 39d2e747-2648-4d68-ae92-bbc70b245055 --pxe --disk pool=default,size=6 --boot=hd,network --network=bridge:docker0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+  virt-install --name node4 -u 4ed46e8e-db69-471e-b874-0990dd65649d --pxe --disk pool=default,size=6 --boot=hd,network --network=bridge:docker0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
 }
 
 function create_rkt {
-  virt-install --name node1 -u 16e7d8a7-bfa9-428b-9117-363341bb330b --pxe --disk pool=default,size=4 --boot=hd,network --network=bridge:metal0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
-  virt-install --name node2 -u 264cd073-ca62-44b3-98c0-50aad5b5f819 --pxe --disk pool=default,size=4 --boot=hd,network --network=bridge:metal0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
-  virt-install --name node3 -u 39d2e747-2648-4d68-ae92-bbc70b245055 --pxe --disk pool=default,size=4 --boot=hd,network --network=bridge:metal0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
-  virt-install --name node4 -u 4ed46e8e-db69-471e-b874-0990dd65649d --pxe --disk pool=default,size=4 --boot=hd,network --network=bridge:metal0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+  virt-install --name node1 -u 16e7d8a7-bfa9-428b-9117-363341bb330b --pxe --disk pool=default,size=6 --boot=hd,network --network=bridge:metal0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+  virt-install --name node2 -u 264cd073-ca62-44b3-98c0-50aad5b5f819 --pxe --disk pool=default,size=6 --boot=hd,network --network=bridge:metal0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+  virt-install --name node3 -u 39d2e747-2648-4d68-ae92-bbc70b245055 --pxe --disk pool=default,size=6 --boot=hd,network --network=bridge:metal0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+  virt-install --name node4 -u 4ed46e8e-db69-471e-b874-0990dd65649d --pxe --disk pool=default,size=6 --boot=hd,network --network=bridge:metal0 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
 }
 
 nodes=(node1 node2 node3 node4)


### PR DESCRIPTION
* 4GB disk is too small and routinely fails in libvirt
* Depending on build env, dnsmasq ACI can have an old /etc/resolv.conf
DNS entry embedded. Can rebuild to fix, but use --dns=8.8.8.8 too
* Fix issue where etcd_proxy profile failed to pull metadata
so etcd_proxy wasn't configured after CoreOS install