### PR TITLE
examples: Upgrade k8s to v1.1.8

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples show declarative configurations for network booting libvirt VMs i
 | pxe-disk | CoreOS via iPXE, with a root filesystem | alpha/962.0.0 | Disk | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
 | coreos-install | 2-stage Ignition: Install CoreOS, provision etcd cluster | alpha/962.0.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
 | etcd-rkt, etcd-docker | Cluster with 3 etcd nodes, 2 proxies | beta/899.6.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
-| k8s-rkt, k8s-docker | Kubernetes cluster with 1 master, 1 worker, 1 dedicated etcd node, TLS-authentication | beta/899.6.0 | RAM | [reference](https://github.com/coreos/coreos-kubernetes) |
+| k8s-rkt, k8s-docker | Kubernetes cluster with 1 master, 1 worker, 1 dedicated etcd node, TLS-authentication | alpha/962.0.0 | Disk | [reference](https://github.com/coreos/coreos-kubernetes) |
 
 ## Experimental
 

--- a/examples/cloud/kubernetes-master.sh
+++ b/examples/cloud/kubernetes-master.sh
@@ -5,7 +5,7 @@ set -e
 export ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER={{.k8s_version}}
+export K8S_VER=v1.1.8_coreos.0
 
 # The CIDR network to use for pod IPs.
 # Each pod launched in the cluster will be assigned an IP out of this range.
@@ -83,7 +83,8 @@ function init_templates {
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-ExecStart=/usr/bin/kubelet \
+Environment=KUBELET_VERSION=${K8S_VER}
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api_servers=http://127.0.0.1:8080 \
   --register-node=false \
   --allow-privileged=true \
@@ -113,7 +114,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    image: quay.io/coreos/hyperkube:$K8S_VER
     command:
     - /hyperkube
     - proxy
@@ -146,7 +147,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    image: quay.io/coreos/hyperkube:$K8S_VER
     command:
     - /hyperkube
     - apiserver
@@ -252,7 +253,7 @@ metadata:
 spec:
   containers:
   - name: kube-controller-manager
-    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    image: quay.io/coreos/hyperkube:$K8S_VER
     command:
     - /hyperkube
     - controller-manager
@@ -298,7 +299,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    image: quay.io/coreos/hyperkube:$K8S_VER
     command:
     - /hyperkube
     - scheduler

--- a/examples/cloud/kubernetes-worker.sh
+++ b/examples/cloud/kubernetes-worker.sh
@@ -10,7 +10,7 @@ export ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
 export CONTROLLER_ENDPOINT={{.k8s_controller_endpoint}}
 
 # Specify the version (vX.Y.Z) of Kubernetes assets to deploy
-export K8S_VER={{.k8s_version}}
+export K8S_VER=v1.1.8_coreos.0
 
 # The IP address of the cluster DNS service.
 # This must be the same DNS_SERVICE_IP used when configuring the controller nodes.
@@ -49,7 +49,8 @@ function init_templates {
         cat << EOF > $TEMPLATE
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-ExecStart=/usr/bin/kubelet \
+Environment=KUBELET_VERSION=${K8S_VER}
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --api_servers=${CONTROLLER_ENDPOINT} \
   --register-node=true \
   --allow-privileged=true \
@@ -106,7 +107,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-proxy
-    image: gcr.io/google_containers/hyperkube:$K8S_VER
+    image: quay.io/coreos/hyperkube:$K8S_VER
     command:
     - /hyperkube
     - proxy

--- a/examples/ignition/network.yaml
+++ b/examples/ignition/network.yaml
@@ -14,6 +14,20 @@ systemd:
         ExecStart=/usr/bin/bash -c 'curl --url "http://bootcfg.foo:8080/metadata?{{.query}}" --retry 10 --output ${OUTPUT}'
         [Install]
         WantedBy=multi-user.target
+storage:
+  disks:
+    - device: /dev/sda
+      wipe_table: true
+      partitions:
+        - label: ROOT
+          number: 0
+  filesystems:
+    - device: "/dev/sda1"
+      format: "ext4"
+      create:
+        force: true
+        options:
+          - "-LROOT"
 networkd:
   units:
     - name: 00-{{.networkd_name}}.network

--- a/examples/k8s-docker.yaml
+++ b/examples/k8s-docker.yaml
@@ -11,7 +11,6 @@ groups:
       networkd_dns: 172.17.0.3
       networkd_address: 172.17.0.21/16
       k8s_etcd_endpoints: http://172.17.0.23:2379
-      k8s_version: v1.1.2
       k8s_pod_network: 10.2.0.0/16
       k8s_service_ip_range: 10.3.0.0/24
       k8s_service_ip: 10.3.0.1
@@ -30,7 +29,6 @@ groups:
       networkd_address: 172.17.0.22/16
       k8s_etcd_endpoints: http://172.17.0.23:2379
       k8s_controller_endpoint: https://172.17.0.21
-      k8s_version: v1.1.2
       k8s_dns_service_ip: 10.3.0.1
       k8s_advertise_ip: 172.17.0.22
       k8s_cert_endpoint: http://bootcfg.foo:8080/assets

--- a/examples/k8s-rkt.yaml
+++ b/examples/k8s-rkt.yaml
@@ -11,7 +11,6 @@ groups:
       networkd_dns: 172.15.0.3
       networkd_address: 172.15.0.21/16
       k8s_etcd_endpoints: http://172.15.0.23:2379
-      k8s_version: v1.1.2
       k8s_pod_network: 10.2.0.0/16
       k8s_service_ip_range: 10.3.0.0/24
       k8s_service_ip: 10.3.0.1
@@ -31,7 +30,6 @@ groups:
       networkd_address: 172.15.0.22/16
       k8s_etcd_endpoints: http://172.15.0.23:2379
       k8s_controller_endpoint: https://172.15.0.21
-      k8s_version: v1.1.2
       k8s_dns_service_ip: 10.3.0.1
       k8s_advertise_ip: 172.15.0.22
       k8s_cert_endpoint: http://bootcfg.foo:8080/assets

--- a/examples/profiles/kubernetes-master/profile.json
+++ b/examples/profiles/kubernetes-master/profile.json
@@ -1,9 +1,10 @@
 {
   "id": "kubernetes-master",
   "boot": {
-    "kernel": "/assets/coreos/899.6.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/899.6.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/962.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/962.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
+      "root": "/dev/sda1",
       "cloud-config-url": "http://bootcfg.foo:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/kubernetes-worker/profile.json
+++ b/examples/profiles/kubernetes-worker/profile.json
@@ -1,9 +1,10 @@
 {
   "id": "kubernetes-worker",
   "boot": {
-    "kernel": "/assets/coreos/899.6.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/899.6.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/962.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/962.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
+      "root": "/dev/sda1",
       "cloud-config-url": "http://bootcfg.foo:8080/cloud?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",


### PR DESCRIPTION
* Upgrade CoreOS Version to Alpha 962.0.0
* rkt run kubelet with the kubelet-wrapper
* Switch to quay.io/coreos/hyperkube
* Provision an ext4 root partition