### PR TITLE
bootcfg/storage: Switch fileStore from http.Dir to custom Dir

### DIFF
--- a/bootcfg/storage/file_store.go
+++ b/bootcfg/storage/file_store.go
@@ -1,0 +1,92 @@
+package storage
+
+import (
+	"encoding/json"
+	"path/filepath"
+
+	"github.com/coreos/coreos-baremetal/bootcfg/storage/storagepb"
+)
+
+// Config initializes a fileStore.
+type Config struct {
+	Dir    string
+	Groups []*storagepb.Group
+}
+
+// fileStore implements ths Store interface. Queries to the file system
+// are restricted to the specified directory tree.
+type fileStore struct {
+	root   string
+	groups map[string]*storagepb.Group
+}
+
+// NewFileStore returns a new memory-backed Store.
+func NewFileStore(config *Config) Store {
+	groups := make(map[string]*storagepb.Group)
+	for _, group := range config.Groups {
+		groups[group.Id] = group
+	}
+	return &fileStore{
+		root:   config.Dir,
+		groups: groups,
+	}
+}
+
+// GroupGet returns a machine Group by id.
+func (s *fileStore) GroupGet(id string) (*storagepb.Group, error) {
+	val, ok := s.groups[id]
+	if !ok {
+		return nil, ErrGroupNotFound
+	}
+	return val, nil
+}
+
+// GroupList lists all machine Groups.
+func (s *fileStore) GroupList() ([]*storagepb.Group, error) {
+	groups := make([]*storagepb.Group, len(s.groups))
+	i := 0
+	for _, g := range s.groups {
+		groups[i] = g
+		i++
+	}
+	return groups, nil
+}
+
+// ProfileGet gets a profile by id.
+func (s *fileStore) ProfileGet(id string) (*storagepb.Profile, error) {
+	data, err := Dir(s.root).readFile(filepath.Join("profiles", id, "profile.json"))
+	profile := new(storagepb.Profile)
+	err = json.Unmarshal(data, profile)
+	if err != nil {
+		return nil, err
+	}
+	return profile, err
+}
+
+// ProfileList lists all profiles.
+func (s *fileStore) ProfileList() ([]*storagepb.Profile, error) {
+	files, err := Dir(s.root).readDir("profiles")
+	if err != nil {
+		return nil, err
+	}
+	profiles := make([]*storagepb.Profile, 0, len(files))
+	for _, finfo := range files {
+		profile, err := s.ProfileGet(finfo.Name())
+		if err == nil {
+			profiles = append(profiles, profile)
+		}
+	}
+	return profiles, nil
+}
+
+// IgnitionGet gets an Ignition Config template by name.
+func (s *fileStore) IgnitionGet(id string) (string, error) {
+	data, err := Dir(s.root).readFile(filepath.Join("ignition", id))
+	return string(data), err
+}
+
+// CloudGet gets a Cloud-Config template by name.
+func (s *fileStore) CloudGet(id string) (string, error) {
+	data, err := Dir(s.root).readFile(filepath.Join("cloud", id))
+	return string(data), err
+}

--- a/bootcfg/storage/fs.go
+++ b/bootcfg/storage/fs.go
@@ -1,0 +1,69 @@
+package storage
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	defaultDirectoryMode        os.FileMode = 0755
+	defaultFileMode             os.FileMode = 0644
+	errInvalidFilePathCharacter             = errors.New("invalid character in file path")
+)
+
+// Dir implements access to a collection of named files, restricted to a
+// specific directory tree. It is very similar to net/http.Dir, but provides
+// io/ioutil methods.
+// An empty directory is treated as ".".
+type Dir string
+
+// readFile reads data from a file at a given path, restricted to a specific
+// directory tree.
+func (d Dir) readFile(path string) ([]byte, error) {
+	path, err := d.sanitize(path)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadFile(path)
+}
+
+// readDir reads the directory named by the given path and returns a list of
+// sorted directory entries. Restricted to a specified directory tree.
+func (d Dir) readDir(dirname string) ([]os.FileInfo, error) {
+	path, err := d.sanitize(dirname)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadDir(path)
+}
+
+// writeFile writes the data as a file at given path, restricted to a specific
+// directory tree.
+func (d Dir) writeFile(path string, data []byte) error {
+	// make parent directories as needed
+	path, err := d.sanitize(path)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), defaultDirectoryMode); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, data, defaultFileMode)
+}
+
+// Borrowed directly from net/http Dir.Open and FileServer.
+func (d Dir) sanitize(name string) (string, error) {
+	if filepath.Separator != '/' && strings.ContainsRune(name, filepath.Separator) ||
+		strings.Contains(name, "\x00") {
+		return "", errInvalidFilePathCharacter
+	}
+	dir := string(d)
+	if dir == "" {
+		dir = "."
+	}
+	return filepath.Join(dir, filepath.FromSlash(path.Clean("/"+name))), nil
+}

--- a/bootcfg/storage/fs_test.go
+++ b/bootcfg/storage/fs_test.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDir(t *testing.T) {
+	tdir, err := ioutil.TempDir("", "bootcfg")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tdir)
+	dir := Dir(tdir)
+	// touch new files
+	cases := []struct {
+		path     string
+		expected string
+	}{
+		{"/a", "a"},
+		{"../b", "b"},
+		{"..c", "..c"},
+		// creates parent directories as needed
+		{"d/e/ff", "d/e/ff"},
+		{"d/e/ff/../gg", "d/e/gg"},
+	}
+	// write files rooted in the dir
+	for _, c := range cases {
+		dir.writeFile(c.path, []byte(c.expected))
+	}
+	// ensure expected files were created
+	for _, c := range cases {
+		_, err := os.Stat(filepath.Join(tdir, c.expected))
+		assert.Nil(t, err)
+	}
+	// ensure expected files can be read by rooted dir
+	for _, c := range cases {
+		b, err := dir.readFile(c.path)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte(c.expected), b)
+	}
+}
+
+func TestSanitizePath(t *testing.T) {
+	cases := []struct {
+		dir      Dir
+		path     string
+		expected string
+		err      error
+	}{
+		{Dir(""), "", ".", nil},
+		{Dir(""), "..", ".", nil},
+		{Dir(""), "../../", ".", nil},
+		{Dir("."), "", ".", nil},
+		{Dir("."), "/../../", ".", nil},
+		{Dir("/etc"), "/hosts", "/etc/hosts", nil},
+		{Dir("/etc"), "hosts", "/etc/hosts", nil},
+		{Dir("/etc"), "../../../hosts", "/etc/hosts", nil},
+		{Dir("/etc/"), "/hosts", "/etc/hosts", nil},
+		{Dir("/etc/"), "hosts", "/etc/hosts", nil},
+		{Dir("/etc/"), "../../../hosts", "/etc/hosts", nil},
+		// zero byte - don't repeat Go bug https://github.com/golang/go/issues/3842
+		{Dir("/etc/"), "/..\x00", "", errInvalidFilePathCharacter},
+	}
+	for _, c := range cases {
+		path, err := c.dir.sanitize(c.path)
+		assert.Equal(t, c.expected, path)
+		assert.Equal(t, c.err, err)
+	}
+}

--- a/bootcfg/storage/storage.go
+++ b/bootcfg/storage/storage.go
@@ -1,17 +1,12 @@
 package storage
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"path/filepath"
 
 	"github.com/coreos/coreos-baremetal/bootcfg/storage/storagepb"
 )
 
-// Errors querying a Store.
+// Storage errors
 var (
 	ErrGroupNotFound   = errors.New("storage: No Group found")
 	ErrProfileNotFound = errors.New("storage: No Profile found")
@@ -23,140 +18,14 @@ type Store interface {
 	GroupGet(id string) (*storagepb.Group, error)
 	// GroupList lists all machine Groups.
 	GroupList() ([]*storagepb.Group, error)
+
 	// ProfileGet gets a profile by id.
 	ProfileGet(id string) (*storagepb.Profile, error)
 	// ProfileList lists all profiles.
 	ProfileList() ([]*storagepb.Profile, error)
+
 	// IgnitionGet gets an Ignition Config template by name.
 	IgnitionGet(name string) (string, error)
 	// CloudGet gets a Cloud-Config template by name.
 	CloudGet(name string) (string, error)
-}
-
-// Config initializes a fileStore.
-type Config struct {
-	Dir    string
-	Groups []*storagepb.Group
-}
-
-// fileStore implements ths Store interface. Queries to the file system
-// are restricted to the specified directory tree.
-type fileStore struct {
-	dir    string
-	groups map[string]*storagepb.Group
-}
-
-// NewFileStore returns a new memory-backed Store.
-func NewFileStore(config *Config) Store {
-	groups := make(map[string]*storagepb.Group)
-	for _, group := range config.Groups {
-		groups[group.Id] = group
-	}
-	return &fileStore{
-		dir:    config.Dir,
-		groups: groups,
-	}
-}
-
-// GroupGet returns a machine Group by id.
-func (s *fileStore) GroupGet(id string) (*storagepb.Group, error) {
-	val, ok := s.groups[id]
-	if !ok {
-		return nil, ErrGroupNotFound
-	}
-	return val, nil
-}
-
-// GroupList lists all machine Groups.
-func (s *fileStore) GroupList() ([]*storagepb.Group, error) {
-	groups := make([]*storagepb.Group, len(s.groups))
-	i := 0
-	for _, g := range s.groups {
-		groups[i] = g
-		i++
-	}
-	return groups, nil
-}
-
-// ProfileGet gets a profile by id.
-func (s *fileStore) ProfileGet(id string) (*storagepb.Profile, error) {
-	file, err := openFile(http.Dir(s.dir), filepath.Join("profiles", id, "profile.json"))
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	profile := new(storagepb.Profile)
-	err = json.NewDecoder(file).Decode(profile)
-	if err != nil {
-		return nil, err
-	}
-	return profile, err
-}
-
-// ProfileList lists all profiles.
-func (s *fileStore) ProfileList() ([]*storagepb.Profile, error) {
-	finfos, err := ioutil.ReadDir(filepath.Join(s.dir, "profiles"))
-	if err != nil {
-		return nil, err
-	}
-	profiles := make([]*storagepb.Profile, 0, len(finfos))
-	for _, finfo := range finfos {
-		profile, err := s.ProfileGet(finfo.Name())
-		if err == nil {
-			profiles = append(profiles, profile)
-		}
-	}
-	return profiles, nil
-}
-
-// IgnitionGet gets an Ignition Config template by name.
-func (s *fileStore) IgnitionGet(id string) (string, error) {
-	file, err := openFile(http.Dir(s.dir), filepath.Join("ignition", id))
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	b, err := ioutil.ReadAll(file)
-	if err != nil {
-		return "", err
-	}
-	return string(b), err
-}
-
-// CloudGet gets a Cloud-Config template by name.
-func (s *fileStore) CloudGet(id string) (string, error) {
-	file, err := openFile(http.Dir(s.dir), filepath.Join("cloud", id))
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	b, err := ioutil.ReadAll(file)
-	if err != nil {
-		return "", err
-	}
-	return string(b), err
-}
-
-// openFile attempts to open the file within the specified Filesystem. If
-// successful, the http.File is returned and must be closed by the caller.
-// Otherwise, the path was not a regular file that could be opened and an
-// error is returned.
-func openFile(fs http.FileSystem, path string) (http.File, error) {
-	file, err := fs.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	info, err := file.Stat()
-	if err != nil {
-		file.Close()
-		return nil, err
-	}
-	if info.Mode().IsRegular() {
-		return file, nil
-	}
-	file.Close()
-	return nil, fmt.Errorf("%s is not a file on the given filesystem", path)
 }


### PR DESCRIPTION
* http.Dir securely restricts accesses to a filesystem directory to
support http FileServe, which is why this type was used originally
* Dir copies the sanatization behavior of http.Dir verbatim, but
provides ioutil-like write and directory access within the directory
* Why: Safe FileStore writes need to be possible and also, storage
should not have a dependency on net/http just for its http.Dir