### PR TITLE
examples: Add a POC of how AWS Ignition serving would work

### DIFF
--- a/examples/groups/etcd-aws/default.json
+++ b/examples/groups/etcd-aws/default.json
@@ -1,0 +1,15 @@
+{
+	"id": "etcd-aws",
+	"name": "etcd Node",
+	"profile": "etcd-aws",
+	"requirements": {
+		"name": "etcd",
+		"platform": "aws"
+	},
+	"metadata": {
+		"etcd_discovery": "token from https://discovery.etcd.io/new?size=N",
+		"ssh_authorized_keys": [
+			"ssh-rsa pub-key-goes-here"
+		]
+	}
+}

--- a/examples/ignition/etcd-aws.yaml
+++ b/examples/ignition/etcd-aws.yaml
@@ -1,0 +1,32 @@
+---
+ignition_version: 1
+systemd:
+  units:
+    - name: etcd2.service
+      enable: true
+      dropins:
+        - name: metadata.conf
+          contents: |
+            [Unit]
+            Requires=coreos-metadata.service
+            After=coreos-metadata.service
+            [Service]
+            EnvironmentFile=/run/metadata/coreos
+            ExecStart=
+            ExecStart=/usr/bin/etcd2 \
+              --advertise-client-urls=http://${COREOS_EC2_IPV4_LOCAL}:2379 \
+              --initial-advertise-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
+              --listen-client-urls=http://0.0.0.0:2379 \
+              --listen-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
+              --discovery={{.etcd_discovery}}
+    - name: fleet.service
+      enable: true
+{{ if .ssh_authorized_keys }}
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        {{ range $element := .ssh_authorized_keys }}
+        - {{$element}}
+        {{end}}
+{{end}}

--- a/examples/profiles/etcd-aws.json
+++ b/examples/profiles/etcd-aws.json
@@ -1,0 +1,5 @@
+{
+  "id": "etcd",
+  "name": "etcd on AWS",
+  "ignition_id": "etcd-aws.yaml"
+}


### PR DESCRIPTION
* Ignition v2.0.0 could fetch the Ignition config from bootcfg
* Sets up the etcd nodes using the discovery endpoint