### PR TITLE
examples: Upgrade k8s from v1.1.8 to v1.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,8 +22,9 @@
 * Change the default assets download location to `examples/assets`
 * Remove HTTP `/spec/id` JSON endpoint
 
-#### New Examples
+#### Examples
 
+* Upgraded Kubernetes examples to v1.2.0
 * Examples which PXE boot with or without a root partition
 * Example Kubernetes cluster installed to disk
 * Example etcd cluster installed to disk

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -83,7 +83,6 @@ Clean up the VM machines.
 
     sudo ./scripts/libvirt poweroff
     sudo ./scripts/libvirt destroy
-    sudo ./scripts/libvirt delete-disks
 
 ## Going Further
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -121,7 +121,6 @@ Press ^] three times to stop a rkt pod. Clean up the VM machines.
 
     sudo ./scripts/libvirt poweroff
     sudo ./scripts/libvirt destroy
-    sudo ./scripts/libvirt delete-disks
 
 ## Going Further
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -61,7 +61,7 @@ See the [Cluster TLS OpenSSL Generation](https://coreos.com/kubernetes/docs/late
 
 ### Verify
 
-Install the `kubectl` CLI on your host. Use the provided kubeconfig's to access the Kubernetes cluster created on rkt `metal0` or `docker0`.
+[Install kubectl](https://coreos.com/kubernetes/docs/latest/configure-kubectl.html) on your host. Use the provided kubeconfig's to access the Kubernetes cluster created on rkt `metal0` or `docker0`.
 
     cd /path/to/coreos-baremetal
     kubectl --kubeconfig=examples/assets/tls/kubeconfig get nodes
@@ -70,7 +70,7 @@ Get all pods.
 
     kubectl --kubeconfig=examples/assets/tls/kubeconfig get pods --all-namespaces
 
-On my laptop, VMs download and network boot CoreOS in the first 45 seconds, the Kubernetes API becomes available after about 150 seconds, and add-on pods are scheduled by 180 seconds. On physical hosts and networks, OS and container image download times are a bit longer.
+On my laptop, VMs download and network boot CoreOS in the first 45 seconds, the Kubernetes API becomes available after about 150 seconds, and add-on pods are scheduled after 3 minutes. On physical hosts and networks, OS and container image download times are a bit longer.
 
 ## Tectonic
 

--- a/examples/groups/k8s-docker/node1.json
+++ b/examples/groups/k8s-docker/node1.json
@@ -16,7 +16,7 @@
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip": "10.3.0.1",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.17.0.21/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-docker/node2.json
+++ b/examples/groups/k8s-docker/node2.json
@@ -14,7 +14,7 @@
     "k8s_controller_endpoint": "https://172.17.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.17.0.22/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-docker/node3.json
+++ b/examples/groups/k8s-docker/node3.json
@@ -14,7 +14,7 @@
     "k8s_controller_endpoint": "https://172.17.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.17.0.23/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-install/node1.json
+++ b/examples/groups/k8s-install/node1.json
@@ -17,7 +17,7 @@
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip": "10.3.0.1",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s-install/node2.json
+++ b/examples/groups/k8s-install/node2.json
@@ -15,7 +15,7 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s-install/node3.json
+++ b/examples/groups/k8s-install/node3.json
@@ -15,7 +15,7 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node1.json
+++ b/examples/groups/k8s/node1.json
@@ -16,7 +16,7 @@
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip": "10.3.0.1",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node2.json
+++ b/examples/groups/k8s/node2.json
@@ -14,7 +14,7 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node3.json
+++ b/examples/groups/k8s/node3.json
@@ -14,7 +14,7 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.1.8_coreos.0",
+    "k8s_version": "v1.2.0_coreos.1",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -67,8 +67,8 @@ systemd:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         Environment=KUBELET_VERSION={{.k8s_version}}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --api_servers=http://127.0.0.1:8080 \
-          --register-node=false \
+          --api-servers=http://127.0.0.1:8080 \
+          --register-schedulable=false \
           --allow-privileged=true \
           --config=/etc/kubernetes/manifests \
           --hostname-override={{.ipv4_address}} \
@@ -82,7 +82,7 @@ systemd:
       enable: true
       contents: |
         [Unit]
-        Description=Start Kubernetes DNS Controller and Service
+        Description=Kubernetes Addons
         Requires=kubelet.service
         After=kubelet.service
         [Service]
@@ -185,59 +185,11 @@ storage:
               - hostPath:
                   path: /usr/share/ca-certificates
                 name: ssl-certs-host
-        - path: /etc/kubernetes/manifests/kube-podmaster.yaml
-          contents: |
-            apiVersion: v1
-            kind: Pod
-            metadata:
-              name: kube-podmaster
-              namespace: kube-system
-            spec:
-              hostNetwork: true
-              containers:
-              - name: scheduler-elector
-                image: gcr.io/google_containers/podmaster:1.1
-                command:
-                - /podmaster
-                - --etcd-servers={{.k8s_etcd_endpoints}}
-                - --key=scheduler
-                - --whoami={{.ipv4_address}}
-                - --source-file=/src/manifests/kube-scheduler.yaml
-                - --dest-file=/dst/manifests/kube-scheduler.yaml
-                volumeMounts:
-                - mountPath: /src/manifests
-                  name: manifest-src
-                  readOnly: true
-                - mountPath: /dst/manifests
-                  name: manifest-dst
-              - name: controller-manager-elector
-                image: gcr.io/google_containers/podmaster:1.1
-                command:
-                - /podmaster
-                - --etcd-servers={{.k8s_etcd_endpoints}}
-                - --key=controller
-                - --whoami={{.ipv4_address}}
-                - --source-file=/src/manifests/kube-controller-manager.yaml
-                - --dest-file=/dst/manifests/kube-controller-manager.yaml
-                terminationMessagePath: /dev/termination-log
-                volumeMounts:
-                - mountPath: /src/manifests
-                  name: manifest-src
-                  readOnly: true
-                - mountPath: /dst/manifests
-                  name: manifest-dst
-              volumes:
-              - hostPath:
-                  path: /srv/kubernetes/manifests
-                name: manifest-src
-              - hostPath:
-                  path: /etc/kubernetes/manifests
-                name: manifest-dst
         - path: /etc/flannel/options.env
           contents: |
             FLANNELD_IFACE={{.ipv4_address}}
             FLANNELD_ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
-        - path: /srv/kubernetes/manifests/kube-controller-manager.yaml
+        - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
           contents: |
             apiVersion: v1
             kind: Pod
@@ -252,6 +204,7 @@ storage:
                 - /hyperkube
                 - controller-manager
                 - --master=http://127.0.0.1:8080
+                - --leader-elect=true
                 - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
                 - --root-ca-file=/etc/kubernetes/ssl/ca.pem
                 livenessProbe:
@@ -276,7 +229,7 @@ storage:
               - hostPath:
                   path: /usr/share/ca-certificates
                 name: ssl-certs-host
-        - path: /srv/kubernetes/manifests/kube-scheduler.yaml
+        - path: /etc/kubernetes/manifests/kube-scheduler.yaml
           contents: |
             apiVersion: v1
             kind: Pod
@@ -292,6 +245,7 @@ storage:
                 - /hyperkube
                 - scheduler
                 - --master=http://127.0.0.1:8080
+                - --leader-elect=true
                 livenessProbe:
                   httpGet:
                     host: 127.0.0.1
@@ -302,150 +256,168 @@ storage:
         - path: /srv/kubernetes/manifests/kube-dns-rc.json
           contents: |
             {
-                "apiVersion": "v1",
-                "kind": "ReplicationController",
-                "metadata": {
-                    "labels": {
-                        "k8s-app": "kube-dns",
-                        "kubernetes.io/cluster-service": "true",
-                        "version": "v9"
-                    },
-                    "name": "kube-dns-v9",
-                    "namespace": "kube-system"
+              "apiVersion": "v1",
+              "kind": "ReplicationController",
+              "metadata": {
+                "labels": {
+                  "k8s-app": "kube-dns",
+                  "kubernetes.io/cluster-service": "true",
+                  "version": "v11"
                 },
-                "spec": {
-                    "replicas": 1,
-                    "selector": {
-                        "k8s-app": "kube-dns",
-                        "version": "v9"
-                    },
-                    "template": {
-                        "metadata": {
-                            "labels": {
-                                "k8s-app": "kube-dns",
-                                "kubernetes.io/cluster-service": "true",
-                                "version": "v9"
-                            }
-                        },
-                        "spec": {
-                            "containers": [
-                                {
-                                    "command": [
-                                        "/usr/local/bin/etcd",
-                                        "-data-dir",
-                                        "/var/etcd/data",
-                                        "-listen-client-urls",
-                                        "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                                        "-advertise-client-urls",
-                                        "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                                        "-initial-cluster-token",
-                                        "skydns-etcd"
-                                    ],
-                                    "image": "gcr.io/google_containers/etcd:2.0.9",
-                                    "name": "etcd",
-                                    "resources": {
-                                        "limits": {
-                                            "cpu": "100m",
-                                            "memory": "50Mi"
-                                        }
-                                    },
-                                    "volumeMounts": [
-                                        {
-                                            "mountPath": "/var/etcd/data",
-                                            "name": "etcd-storage"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "args": [
-                                        "-domain=cluster.local"
-                                    ],
-                                    "image": "gcr.io/google_containers/kube2sky:1.11",
-                                    "name": "kube2sky",
-                                    "resources": {
-                                        "limits": {
-                                            "cpu": "100m",
-                                            "memory": "50Mi"
-                                        }
-                                    }
-                                },
-                                {
-                                    "args": [
-                                        "-machines=http://127.0.0.1:4001",
-                                        "-addr=0.0.0.0:53",
-                                        "-ns-rotate=false",
-                                        "-domain=cluster.local."
-                                    ],
-                                    "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-                                    "livenessProbe": {
-                                        "httpGet": {
-                                            "path": "/healthz",
-                                            "port": 8080,
-                                            "scheme": "HTTP"
-                                        },
-                                        "initialDelaySeconds": 30,
-                                        "timeoutSeconds": 5
-                                    },
-                                    "name": "skydns",
-                                    "ports": [
-                                        {
-                                            "containerPort": 53,
-                                            "name": "dns",
-                                            "protocol": "UDP"
-                                        },
-                                        {
-                                            "containerPort": 53,
-                                            "name": "dns-tcp",
-                                            "protocol": "TCP"
-                                        }
-                                    ],
-                                    "readinessProbe": {
-                                        "httpGet": {
-                                            "path": "/healthz",
-                                            "port": 8080,
-                                            "scheme": "HTTP"
-                                        },
-                                        "initialDelaySeconds": 1,
-                                        "timeoutSeconds": 5
-                                    },
-                                    "resources": {
-                                        "limits": {
-                                            "cpu": "100m",
-                                            "memory": "50Mi"
-                                        }
-                                    }
-                                },
-                                {
-                                    "args": [
-                                        "-cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null",
-                                        "-port=8080"
-                                    ],
-                                    "image": "gcr.io/google_containers/exechealthz:1.0",
-                                    "name": "healthz",
-                                    "ports": [
-                                        {
-                                            "containerPort": 8080,
-                                            "protocol": "TCP"
-                                        }
-                                    ],
-                                    "resources": {
-                                        "limits": {
-                                            "cpu": "10m",
-                                            "memory": "20Mi"
-                                        }
-                                    }
-                                }
-                            ],
-                            "dnsPolicy": "Default",
-                            "volumes": [
-                                {
-                                    "emptyDir": {},
-                                    "name": "etcd-storage"
-                                }
-                            ]
-                        }
+                "name": "kube-dns-v11",
+                "namespace": "kube-system"
+              },
+              "spec": {
+                "replicas": 1,
+                "selector": {
+                    "k8s-app": "kube-dns",
+                    "version": "v11"
+                },
+                "template": {
+                  "metadata": {
+                    "labels": {
+                      "k8s-app": "kube-dns",
+                      "kubernetes.io/cluster-service": "true",
+                      "version": "v11"
                     }
+                  },
+                  "spec": {
+                    "containers": [
+                        {
+                          "command": [
+                            "/usr/local/bin/etcd",
+                            "-data-dir",
+                            "/var/etcd/data",
+                            "-listen-client-urls",
+                            "http://127.0.0.1:2379,http://127.0.0.1:4001",
+                            "-advertise-client-urls",
+                            "http://127.0.0.1:2379,http://127.0.0.1:4001",
+                            "-initial-cluster-token",
+                            "skydns-etcd"
+                          ],
+                          "image": "gcr.io/google_containers/etcd-amd64:2.2.1",
+                          "name": "etcd",
+                          "resources": {
+                            "limits": {
+                              "cpu": "100m",
+                              "memory": "500Mi"
+                            },
+                            "requests": {
+                              "cpu": "100m",
+                              "memory": "50Mi"
+                            }
+                          },
+                          "volumeMounts": [
+                            {
+                              "mountPath": "/var/etcd/data",
+                              "name": "etcd-storage"
+                            }
+                          ]
+                        },
+                        {
+                          "args": [
+                            "--domain=cluster.local"
+                          ],
+                          "image": "gcr.io/google_containers/kube2sky:1.14",
+                          "livenessProbe": {
+                            "failureThreshold": 5,
+                            "httpGet": {
+                              "path": "/healthz",
+                              "port": 8080,
+                              "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                          },
+                          "name": "kube2sky",
+                          "readinessProbe": {
+                            "httpGet": {
+                              "path": "/readiness",
+                              "port": 8081,
+                              "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 30,
+                            "timeoutSeconds": 5
+                          },
+                          "resources": {
+                            "limits": {
+                              "cpu": "100m",
+                              "memory": "200Mi"
+                            },
+                            "requests": {
+                              "cpu": "100m",
+                              "memory": "50Mi"
+                            }
+                          }
+                        },
+                        {
+                          "args": [
+                            "-machines=http://127.0.0.1:4001",
+                            "-addr=0.0.0.0:53",
+                            "-ns-rotate=false",
+                            "-domain=cluster.local."
+                          ],
+                          "image": "gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
+                          "name": "skydns",
+                          "ports": [
+                            {
+                              "containerPort": 53,
+                              "name": "dns",
+                              "protocol": "UDP"
+                            },
+                            {
+                              "containerPort": 53,
+                              "name": "dns-tcp",
+                              "protocol": "TCP"
+                            }
+                          ],
+                          "resources": {
+                            "limits": {
+                              "cpu": "100m",
+                              "memory": "200Mi"
+                            },
+                            "requests": {
+                              "cpu": "100m",
+                              "memory": "50Mi"
+                            }
+                          }
+                        },
+                        {
+                          "args": [
+                            "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
+                            "-port=8080"
+                          ],
+                          "image": "gcr.io/google_containers/exechealthz:1.0",
+                          "name": "healthz",
+                          "ports": [
+                            {
+                              "containerPort": 8080,
+                              "protocol": "TCP"
+                            }
+                          ],
+                          "resources": {
+                            "limits": {
+                              "cpu": "10m",
+                              "memory": "20Mi"
+                            },
+                            "requests": {
+                              "cpu": "10m",
+                              "memory": "20Mi"
+                            }
+                          }
+                        }
+                    ],
+                    "dnsPolicy": "Default",
+                    "volumes": [
+                      {
+                        "emptyDir": {},
+                        "name": "etcd-storage"
+                      }
+                    ]
+                  }
                 }
+              }
             }
         - path: /srv/kubernetes/manifests/kube-dns-svc.json
           contents: |
@@ -526,10 +498,10 @@ storage:
               sleep 5
             done
             echo "K8S: kube-system namespace"
-            curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-system.json)" "http://127.0.0.1:8080/api/v1/namespaces" > /dev/null
+            curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-system.json)" "http://127.0.0.1:8080/api/v1/namespaces" > /dev/null
             echo "K8S: DNS addon"
-            curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
-            curl --silent -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+            curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+            curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
             
 networkd:
   units:

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -64,7 +64,7 @@ systemd:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         Environment=KUBELET_VERSION={{.k8s_version}}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --api_servers={{.k8s_controller_endpoint}} \
+          --api-servers={{.k8s_controller_endpoint}} \
           --register-node=true \
           --allow-privileged=true \
           --config=/etc/kubernetes/manifests \


### PR DESCRIPTION
Validated both iPXE booted clusters and Installed to Disk clusters using `bootcfg` running via rkt (i.e. `k8s` and `k8s-install` examples). Tested with Tectonic Console and some `Deployments`. Resolves #122 

@pbx0 @aaronlevy