### PR TITLE
bootcfg/: Rename and document packages with their purpose

### DIFF
--- a/bootcfg/cli/doc.go
+++ b/bootcfg/cli/doc.go
@@ -1,0 +1,2 @@
+// Package cli provides a command line interface client.
+package cli

--- a/bootcfg/cli/error.go
+++ b/bootcfg/cli/error.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"fmt"

--- a/bootcfg/cli/format.go
+++ b/bootcfg/cli/format.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"io"

--- a/bootcfg/cli/group.go
+++ b/bootcfg/cli/group.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"github.com/spf13/cobra"

--- a/bootcfg/cli/group_create.go
+++ b/bootcfg/cli/group_create.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"io/ioutil"

--- a/bootcfg/cli/group_describe.go
+++ b/bootcfg/cli/group_describe.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"fmt"

--- a/bootcfg/cli/group_list.go
+++ b/bootcfg/cli/group_list.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"fmt"

--- a/bootcfg/cli/instance.go
+++ b/bootcfg/cli/instance.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"github.com/spf13/cobra"

--- a/bootcfg/cli/instance_list.go
+++ b/bootcfg/cli/instance_list.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"fmt"

--- a/bootcfg/cli/profile.go
+++ b/bootcfg/cli/profile.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"github.com/spf13/cobra"

--- a/bootcfg/cli/profile_create.go
+++ b/bootcfg/cli/profile_create.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"io/ioutil"

--- a/bootcfg/cli/profile_describe.go
+++ b/bootcfg/cli/profile_describe.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"fmt"

--- a/bootcfg/cli/profile_list.go
+++ b/bootcfg/cli/profile_list.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"fmt"

--- a/bootcfg/cli/root.go
+++ b/bootcfg/cli/root.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"fmt"

--- a/bootcfg/cli/version.go
+++ b/bootcfg/cli/version.go
@@ -1,4 +1,4 @@
-package cmd
+package cli
 
 import (
 	"fmt"

--- a/bootcfg/client/doc.go
+++ b/bootcfg/client/doc.go
@@ -1,0 +1,2 @@
+// Package client provides the bootcfg gRPC client.
+package client

--- a/bootcfg/http/cloud.go
+++ b/bootcfg/http/cloud.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"bytes"

--- a/bootcfg/http/cloud_test.go
+++ b/bootcfg/http/cloud_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"net/http"

--- a/bootcfg/http/context.go
+++ b/bootcfg/http/context.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"errors"

--- a/bootcfg/http/context_test.go
+++ b/bootcfg/http/context_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"testing"

--- a/bootcfg/http/doc.go
+++ b/bootcfg/http/doc.go
@@ -1,0 +1,2 @@
+// Package http provides the bootcfg HTTP server
+package http

--- a/bootcfg/http/grub.go
+++ b/bootcfg/http/grub.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"bytes"

--- a/bootcfg/http/handlers.go
+++ b/bootcfg/http/handlers.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"net/http"

--- a/bootcfg/http/handlers_test.go
+++ b/bootcfg/http/handlers_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"fmt"

--- a/bootcfg/http/http.go
+++ b/bootcfg/http/http.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"net"

--- a/bootcfg/http/http_test.go
+++ b/bootcfg/http/http_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"fmt"

--- a/bootcfg/http/ignition.go
+++ b/bootcfg/http/ignition.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"bytes"

--- a/bootcfg/http/ignition_test.go
+++ b/bootcfg/http/ignition_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"net/http"

--- a/bootcfg/http/ipxe.go
+++ b/bootcfg/http/ipxe.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"bytes"

--- a/bootcfg/http/ipxe_test.go
+++ b/bootcfg/http/ipxe_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"net/http"

--- a/bootcfg/http/metadata.go
+++ b/bootcfg/http/metadata.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"encoding/json"

--- a/bootcfg/http/metadata_test.go
+++ b/bootcfg/http/metadata_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"bufio"

--- a/bootcfg/http/pixiecore.go
+++ b/bootcfg/http/pixiecore.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"net/http"

--- a/bootcfg/http/pixiecore_test.go
+++ b/bootcfg/http/pixiecore_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"net/http"

--- a/bootcfg/http/serialize.go
+++ b/bootcfg/http/serialize.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"encoding/json"

--- a/bootcfg/http/serialize_test.go
+++ b/bootcfg/http/serialize_test.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"fmt"

--- a/bootcfg/http/server.go
+++ b/bootcfg/http/server.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"net/http"

--- a/bootcfg/http/test_fixtures.go
+++ b/bootcfg/http/test_fixtures.go
@@ -1,4 +1,4 @@
-package api
+package http
 
 import (
 	"github.com/coreos/coreos-baremetal/bootcfg/storage/storagepb"

--- a/bootcfg/rpc/doc.go
+++ b/bootcfg/rpc/doc.go
@@ -1,0 +1,2 @@
+// Package rpc provides the bootcfg gRPC server
+package rpc

--- a/bootcfg/server/doc.go
+++ b/bootcfg/server/doc.go
@@ -1,0 +1,2 @@
+// Package server is a bootcfg library package for implementing servers.
+package server

--- a/bootcfg/sign/doc.go
+++ b/bootcfg/sign/doc.go
@@ -1,0 +1,2 @@
+// Package sign adds signatures to bootcfg responses.
+package sign

--- a/bootcfg/storage/doc.go
+++ b/bootcfg/storage/doc.go
@@ -1,0 +1,2 @@
+// Package storage defines bootcfg's storage and object types.
+package storage

--- a/cmd/bootcfg/main.go
+++ b/cmd/bootcfg/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/coreos/pkg/flagutil"
 
-	"github.com/coreos/coreos-baremetal/bootcfg/api"
+	web "github.com/coreos/coreos-baremetal/bootcfg/http"
 	"github.com/coreos/coreos-baremetal/bootcfg/rpc"
 	"github.com/coreos/coreos-baremetal/bootcfg/server"
 	"github.com/coreos/coreos-baremetal/bootcfg/sign"
@@ -100,13 +100,13 @@ func main() {
 		Root: flags.dataPath,
 	})
 
-	bootcfgServer := server.NewServer(&server.Config{
+	server := server.NewServer(&server.Config{
 		Store: store,
 	})
 
 	// gRPC Server (feature hidden)
 	if flags.rpcAddress != "" {
-		grpcServer, err := rpc.NewServer(bootcfgServer)
+		grpcServer, err := rpc.NewServer(server)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -120,13 +120,13 @@ func main() {
 	}
 
 	// HTTP Server
-	config := &api.Config{
+	config := &web.Config{
 		Store:         store,
 		AssetsPath:    flags.assetsPath,
 		Signer:        signer,
 		ArmoredSigner: armoredSigner,
 	}
-	httpServer := api.NewServer(config)
+	httpServer := web.NewServer(config)
 	log.Infof("starting bootcfg HTTP server on %s", flags.address)
 	err = http.ListenAndServe(flags.address, httpServer.HTTPHandler())
 	if err != nil {

--- a/cmd/bootcmd/main.go
+++ b/cmd/bootcmd/main.go
@@ -3,5 +3,5 @@ package main
 import "github.com/coreos/coreos-baremetal/bootcfg/cli"
 
 func main() {
-	cmd.Execute()
+	cli.Execute()
 }


### PR DESCRIPTION
Packages
* bootcfg/cli - provides a command line interface client
* bootcfg/http - provides the bootcfg HTTP server
* bootcfg/rpc - provides the bootcfg gRPC server
* bootcfg/client - provides the bootcfg gRPC client
* bootcfg/server - is a bootcfg library package for implementing servers
* bootcfg/storage - defines bootcfg's storage and object types

Binaries
* cmd/bootcfg - HTTP/gRPC server binary
* cmd/bootcmd - command line tool