### PR TITLE
bootcfg/http: Add selectors to template data

### DIFF
--- a/bootcfg/http/cloud.go
+++ b/bootcfg/http/cloud.go
@@ -49,6 +49,9 @@ func cloudHandler(srv server.Server) ContextHandler {
 				return
 			}
 		}
+		for key, value := range group.Selector {
+			data[strings.ToLower(key)] = value
+		}
 
 		// render the template of a cloud config with data
 		var buf bytes.Buffer

--- a/bootcfg/http/cloud_test.go
+++ b/bootcfg/http/cloud_test.go
@@ -14,7 +14,20 @@ import (
 )
 
 func TestCloudHandler(t *testing.T) {
-	content := "#cloud-config"
+	content := `#cloud-config
+coreos:
+  etcd2:
+    name: {{.uuid}}
+  units:
+    - name: {{.service_name}}
+`
+	expected := `#cloud-config
+coreos:
+  etcd2:
+    name: a1b2c3d4
+  units:
+    - name: etcd2
+`
 	store := &fake.FixedStore{
 		Profiles:     map[string]*storagepb.Profile{fake.Group.Profile: fake.Profile},
 		CloudConfigs: map[string]string{fake.Profile.CloudId: content},
@@ -26,9 +39,9 @@ func TestCloudHandler(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	h.ServeHTTP(ctx, w, req)
 	// assert that:
-	// - Cloud config is rendered with Group metadata
+	// - Cloud config is rendered with Group metadata and selectors
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, content, w.Body.String())
+	assert.Equal(t, expected, w.Body.String())
 }
 
 func TestCloudHandler_MissingCtxProfile(t *testing.T) {

--- a/bootcfg/http/ignition.go
+++ b/bootcfg/http/ignition.go
@@ -47,6 +47,9 @@ func ignitionHandler(srv server.Server) ContextHandler {
 			}
 		}
 		data["query"] = req.URL.RawQuery
+		for key, value := range group.Selector {
+			data[strings.ToLower(key)] = value
+		}
 
 		// render the template for an Ignition config with data
 		var buf bytes.Buffer

--- a/bootcfg/http/metadata.go
+++ b/bootcfg/http/metadata.go
@@ -29,12 +29,11 @@ func metadataHandler() ContextHandler {
 				return
 			}
 		}
+		for key, value := range group.Selector {
+			data[key] = value
+		}
 
 		for key, value := range data {
-			fmt.Fprintf(w, "%s=%v\n", strings.ToUpper(key), value)
-		}
-		attrs := labelsFromRequest(req)
-		for key, value := range attrs {
 			fmt.Fprintf(w, "%s=%v\n", strings.ToUpper(key), value)
 		}
 	}

--- a/bootcfg/http/metadata_test.go
+++ b/bootcfg/http/metadata_test.go
@@ -18,18 +18,16 @@ func TestMetadataHandler(t *testing.T) {
 	h := metadataHandler()
 	ctx := withGroup(context.Background(), fake.Group)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/?uuid=a1b2c3d4&mac="+validMACStr, nil)
+	req, _ := http.NewRequest("GET", "/?uuid=a1b2c3d4", nil)
 	h.ServeHTTP(ctx, w, req)
 	// assert that:
-	// - the Group's custom metadata is served
-	// - query argument attributes are added to the metadata
+	// - the Group's custom metadata and selectors are served
 	// - key names are upper case
 	expectedData := map[string]string{
 		"K8S_VERSION":  "v1.1.2",
 		"POD_NETWORK":  "10.2.0.0/16",
 		"SERVICE_NAME": "etcd2",
 		"UUID":         "a1b2c3d4",
-		"MAC":          validMACStr,
 	}
 	assert.Equal(t, http.StatusOK, w.Code)
 	// convert response (random order) to map (tests compare in order)


### PR DESCRIPTION
* Ignition and Cloud config templates can reference selector key/value pairs by lowercase key name
* Metadata endpoint will provide metadata and selector key/val pairs for the matching machine group

With a group definition like the following, it is possible to reference `{{.uuid}}`, `{{.mac}}`, and {{.networkd_gateway}} in Ignition and Cloud config templates. The three values would also be provided to matching machines at the `/metadata` endpoint.

```
{
  "id": "master-node",
  "name": "Kubernetes Master",
  "profile": "k8s-master",
  "selector": {
    "uuid": "c307f480-7277-11e3-8720-abcdabcdeadb",
    "mac": "52:da:00:89:d8:10"
  },
  "metadata": {
    "networkd_gateway": "192.168.1.1"
  }
}
```

Previously, only `{{.networkd_gateway}}` could be used. Resolves #64.