### PR TITLE
examples/ignition: Fix k8s-certs@.service file check

### DIFF
--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -43,7 +43,7 @@ systemd:
         After=network-online.target
         [Service]
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ssl
-        ExecStart=/usr/bin/bash -c "[ -f {{.k8s_cert_endpoint}}/tls/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
+        ExecStart=/usr/bin/bash -c "[ -f /etc/kubernetes/ssl/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
     - name: k8s-assets.target
       contents: |
         [Unit]

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -42,7 +42,7 @@ systemd:
         After=network-online.target
         [Service]
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ssl
-        ExecStart=/usr/bin/bash -c "[ -f {{.k8s_cert_endpoint}}/tls/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
+        ExecStart=/usr/bin/bash -c "[ -f /etc/kubernetes/ssl/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
     - name: k8s-assets.target
       contents: |
         [Unit]


### PR DESCRIPTION
* In the k8s-install example, the k8s-certs@.service checks for
the wrong file and always attempts to curl TLS assets from bootcfg.
After restarts or auto-updates, if bootcfg is not running, the certs
are present on disk so the kubelet and k8s cluster operate normally,
while k8s-certs services fail (mostly harmless).
* Fixes k8s-certs@service failures after restarts when bootcfg is
unavailable. Provisioned nodes should not have a hard dependency on
bootcfg service.