### PR TITLE
examples: Upgrade k8s from v1.2.0 to v1.2.2

### DIFF
--- a/examples/groups/k8s-docker/node1.json
+++ b/examples/groups/k8s-docker/node1.json
@@ -15,7 +15,7 @@
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.17.0.21/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-docker/node2.json
+++ b/examples/groups/k8s-docker/node2.json
@@ -14,7 +14,7 @@
     "k8s_controller_endpoint": "https://172.17.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.17.0.22/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-docker/node3.json
+++ b/examples/groups/k8s-docker/node3.json
@@ -14,7 +14,7 @@
     "k8s_controller_endpoint": "https://172.17.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.17.0.23/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-install/node1.json
+++ b/examples/groups/k8s-install/node1.json
@@ -16,7 +16,7 @@
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s-install/node2.json
+++ b/examples/groups/k8s-install/node2.json
@@ -15,7 +15,7 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s-install/node3.json
+++ b/examples/groups/k8s-install/node3.json
@@ -15,7 +15,7 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node1.json
+++ b/examples/groups/k8s/node1.json
@@ -15,7 +15,7 @@
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node2.json
+++ b/examples/groups/k8s/node2.json
@@ -14,7 +14,7 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node3.json
+++ b/examples/groups/k8s/node3.json
@@ -14,7 +14,7 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.1",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.2.0_coreos.1",
+    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -452,15 +452,16 @@ storage:
                 }
               }
             }
-        - path: /srv/kubernetes/manifests/heapster-rc.json
+        - path: /srv/kubernetes/manifests/heapster-deployment.json
           contents: |
             {
-              "apiVersion": "v1",
-              "kind": "ReplicationController",
+              "apiVersion": "extensions/v1beta1",
+              "kind": "Deployment",
               "metadata": {
                 "labels": {
                   "k8s-app": "heapster",
-                  "kubernetes.io/cluster-service": "true"
+                  "kubernetes.io/cluster-service": "true",
+                  "version": "v1.0.2"
                 },
                 "name": "heapster-v1.0.2",
                 "namespace": "kube-system"
@@ -468,13 +469,16 @@ storage:
               "spec": {
                 "replicas": 1,
                 "selector": {
-                  "k8s-app": "heapster"
+                  "matchLabels": {
+                    "k8s-app": "heapster",
+                    "version": "v1.0.2"
+                  }
                 },
                 "template": {
                   "metadata": {
                     "labels": {
                       "k8s-app": "heapster",
-                      "kubernetes.io/cluster-service": "true"
+                      "version": "v1.0.2"
                     }
                   },
                   "spec": {
@@ -490,11 +494,54 @@ storage:
                         "resources": {
                           "limits": {
                             "cpu": "100m",
-                            "memory": "208Mi"
+                            "memory": "250Mi"
                           },
                           "requests": {
                             "cpu": "100m",
-                            "memory": "208Mi"
+                            "memory": "250Mi"
+                          }
+                        }
+                      },
+                      {
+                        "command": [
+                          "/pod_nanny",
+                          "--cpu=100m",
+                          "--extra-cpu=0m",
+                          "--memory=250Mi",
+                          "--extra-memory=4Mi",
+                          "--threshold=5",
+                          "--deployment=heapster-v1.0.2",
+                          "--container=heapster",
+                          "--poll-period=300000"
+                        ],
+                        "env": [
+                          {
+                            "name": "MY_POD_NAME",
+                            "valueFrom": {
+                              "fieldRef": {
+                                "fieldPath": "metadata.name"
+                              }
+                            }
+                          },
+                          {
+                            "name": "MY_POD_NAMESPACE",
+                            "valueFrom": {
+                              "fieldRef": {
+                                "fieldPath": "metadata.namespace"
+                              }
+                            }
+                          }
+                        ],
+                        "image": "gcr.io/google_containers/addon-resizer:1.0",
+                        "name": "heapster-nanny",
+                        "resources": {
+                          "limits": {
+                            "cpu": "50m",
+                            "memory": "100Mi"
+                          },
+                          "requests": {
+                            "cpu": "50m",
+                            "memory": "100Mi"
                           }
                         }
                       }
@@ -579,7 +626,7 @@ storage:
             curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
             curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
             echo "K8S: Heapster addon"
-            curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+            curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-deployment.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments" > /dev/null
             curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
             
 networkd:

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -43,7 +43,7 @@ systemd:
         After=network-online.target
         [Service]
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ssl
-        ExecStart=/usr/bin/bash -c "[ -f {{.k8s_cert_endpoint}}/tls/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
+        ExecStart=/usr/bin/bash -c "[ -f /etc/kubernetes/ssl/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
     - name: k8s-assets.target
       contents: |
         [Unit]

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -42,7 +42,7 @@ systemd:
         After=network-online.target
         [Service]
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ssl
-        ExecStart=/usr/bin/bash -c "[ -f {{.k8s_cert_endpoint}}/tls/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
+        ExecStart=/usr/bin/bash -c "[ -f /etc/kubernetes/ssl/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
     - name: k8s-assets.target
       contents: |
         [Unit]


### PR DESCRIPTION
* Change Heapster from a rc to a deployment
* Use the heapster-nanny resizer
* Closes #152 