### PR TITLE
bootcmd: fix index-out-of-range on nonsensical describe command

### DIFF
--- a/bootcfg/cli/group_describe.go
+++ b/bootcfg/cli/group_describe.go
@@ -22,8 +22,14 @@ func init() {
 }
 
 func runGroupDescribeCmd(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Help()
+		return
+	}
+
 	tw := newTabWriter(os.Stdout)
 	defer tw.Flush()
+
 	// legend
 	fmt.Fprintf(tw, "ID\tNAME\tSELECTORS\tPROFILE\tMETADATA\n")
 

--- a/bootcfg/cli/profile_describe.go
+++ b/bootcfg/cli/profile_describe.go
@@ -22,6 +22,11 @@ func init() {
 }
 
 func runProfileDescribeCmd(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Help()
+		return
+	}
+
 	tw := newTabWriter(os.Stdout)
 	defer tw.Flush()
 	// legend


### PR DESCRIPTION
This PR prevents the following
```sh
 $ ./bin/bootcmd --endpoints 172.15.0.2:8081 group describe
ID      NAME    SELECTORS       PROFILE METADATA
panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x8c4680, 0xc82000e120)
        /home/joe/.gvm/gos/go1.6.1/src/runtime/panic.go:464 +0x3e6
github.com/coreos/coreos-baremetal/bootcfg/cli.runGroupDescribeCmd(0xc11760, 0xc820195420, 0x0, 0x2)
        /home/joe/.gvm/pkgsets/go1.6.1/global/src/github.com/coreos/coreos-baremetal/bootcfg/cli/group_describe.go:32 +0x63c
github.com/coreos/coreos-baremetal/vendor/github.com/spf13/cobra.(*Command).execute(0xc11760, 0xc8201952e0, 0x2, 0x2, 0x0, 0x0)
        /home/joe/.gvm/pkgsets/go1.6.1/global/src/github.com/coreos/coreos-baremetal/vendor/github.com/spf13/cobra/command.go:569 +0x85a
github.com/coreos/coreos-baremetal/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc12760, 0xc11760, 0x0, 0x0)
        /home/joe/.gvm/pkgsets/go1.6.1/global/src/github.com/coreos/coreos-baremetal/vendor/github.com/spf13/cobra/command.go:656 +0x55c
github.com/coreos/coreos-baremetal/vendor/github.com/spf13/cobra.(*Command).Execute(0xc12760, 0x0, 0x0)
        /home/joe/.gvm/pkgsets/go1.6.1/global/src/github.com/coreos/coreos-baremetal/vendor/github.com/spf13/cobra/command.go:615 +0x2d
github.com/coreos/coreos-baremetal/bootcfg/cli.Execute()
        /home/joe/.gvm/pkgsets/go1.6.1/global/src/github.com/coreos/coreos-baremetal/bootcfg/cli/root.go:35 +0x27
main.main()
        /home/joe/.gvm/pkgsets/go1.6.1/global/src/github.com/coreos/coreos-baremetal/cmd/bootcmd/main.go:6 +0x14

```