### PR TITLE
Improvements to logging and version display

### DIFF
--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -20,7 +20,7 @@ Configuration arguments can be provided as flags or as environment variables.
 | data      | /var/lib/bootcfg/{profiles,groups,ignition,cloud} |
 | assets    | /var/lib/bootcfg/assets |
 
-## Check Version
+## Version
 
     ./bin/bootcfg -version
     sudo rkt --insecure-options=image run quay.io/coreos/bootcfg:latest -- -version

--- a/bootcfg/http/handlers.go
+++ b/bootcfg/http/handlers.go
@@ -1,12 +1,14 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 
 	"golang.org/x/net/context"
 
 	"github.com/coreos/coreos-baremetal/bootcfg/server"
 	pb "github.com/coreos/coreos-baremetal/bootcfg/server/serverpb"
+	"github.com/coreos/coreos-baremetal/bootcfg/version"
 )
 
 // requireGET requires requests to be an HTTP GET. Otherwise, it responds with
@@ -27,6 +29,19 @@ func logRequests(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
 		log.Debugf("HTTP %s %v", req.Method, req.URL)
 		next.ServeHTTP(w, req)
+	}
+	return http.HandlerFunc(fn)
+}
+
+// versionHandler shows the server name and version for root requests.
+// Otherwise, a 404 is returned.
+func versionHandler() http.Handler {
+	fn := func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/" {
+			http.NotFound(w, req)
+			return
+		}
+		fmt.Fprintf(w, "bootcfg version: %s", version.Version)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/bootcfg/http/server.go
+++ b/bootcfg/http/server.go
@@ -10,7 +10,7 @@ import (
 	"github.com/coreos/coreos-baremetal/bootcfg/storage"
 )
 
-var log = capnslog.NewPackageLogger("github.com/coreos/coreos-baremetal/bootcfg", "api")
+var log = capnslog.NewPackageLogger("github.com/coreos/coreos-baremetal/bootcfg", "http")
 
 // Config configures the api Server.
 type Config struct {

--- a/bootcfg/http/server.go
+++ b/bootcfg/http/server.go
@@ -46,6 +46,8 @@ func (s *Server) HTTPHandler() http.Handler {
 	mux := http.NewServeMux()
 	srv := server.NewServer(&server.Config{s.store})
 
+	// bootcfg version
+	mux.Handle("/", logRequests(versionHandler()))
 	// Boot via GRUB
 	mux.Handle("/grub", logRequests(NewHandler(selectProfile(srv, grubHandler()))))
 	// Boot via iPXE

--- a/bootcfg/version/version.go
+++ b/bootcfg/version/version.go
@@ -1,0 +1,5 @@
+// Package version provides the bootcfg version.
+package version
+
+// Version provided by compile time -ldflags.
+var Version = "was not built properly"

--- a/build
+++ b/build
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-LD_FLAGS="-w -X main.version=$(./git-version)"
+LD_FLAGS="-w -X github.com/coreos/coreos-baremetal/bootcfg/version.Version=$(./git-version)"
 CGO_ENABLED=0 go build -o bin/bootcfg -ldflags "$LD_FLAGS" -a -tags netgo github.com/coreos/coreos-baremetal/cmd/bootcfg
 
 # bootcmd CLI binary

--- a/cmd/bootcfg/main.go
+++ b/cmd/bootcfg/main.go
@@ -17,12 +17,11 @@ import (
 	"github.com/coreos/coreos-baremetal/bootcfg/server"
 	"github.com/coreos/coreos-baremetal/bootcfg/sign"
 	"github.com/coreos/coreos-baremetal/bootcfg/storage"
+	"github.com/coreos/coreos-baremetal/bootcfg/version"
 )
 
 var (
-	// version provided by compile time flag: -ldflags "-X main.version $GIT_SHA"
-	version = "was not built properly"
-	log     = capnslog.NewPackageLogger("github.com/coreos/coreos-baremetal/cmd/bootcfg", "main")
+	log = capnslog.NewPackageLogger("github.com/coreos/coreos-baremetal/cmd/bootcfg", "main")
 )
 
 func main() {
@@ -56,7 +55,7 @@ func main() {
 	passphrase := os.Getenv("BOOTCFG_PASSPHRASE")
 
 	if flags.version {
-		fmt.Println(version)
+		fmt.Println(version.Version)
 		return
 	}
 


### PR DESCRIPTION
* Add `bootcfg/version` package
* Show the `bootcfg` version via the HTTP server at "/" (e.g. `bootcfg version: 7629ac4813781cdf3fe2d3a9f96bc04084b21856`) to supplement the `-version` command line flag.
* Add logging for / rooted tree requests to surface more bad queries
* Fixes incorrect package name in logs #173 