### PR TITLE
examples/groups/k8s: Fix DNS resolution in pods

### DIFF
--- a/examples/groups/k8s-docker/node2.json
+++ b/examples/groups/k8s-docker/node2.json
@@ -12,7 +12,7 @@
     "ipv4_address": "172.17.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.17.0.21",
-    "k8s_dns_service_ip": "10.3.0.1",
+    "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
     "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.17.0.22/16",

--- a/examples/groups/k8s-docker/node3.json
+++ b/examples/groups/k8s-docker/node3.json
@@ -12,7 +12,7 @@
     "ipv4_address": "172.17.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.17.0.21",
-    "k8s_dns_service_ip": "10.3.0.1",
+    "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
     "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.17.0.23/16",

--- a/examples/groups/k8s-install/node2.json
+++ b/examples/groups/k8s-install/node2.json
@@ -13,7 +13,7 @@
     "ipv4_address": "172.15.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",
-    "k8s_dns_service_ip": "10.3.0.1",
+    "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.22/16",

--- a/examples/groups/k8s-install/node3.json
+++ b/examples/groups/k8s-install/node3.json
@@ -13,7 +13,7 @@
     "ipv4_address": "172.15.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",
-    "k8s_dns_service_ip": "10.3.0.1",
+    "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.23/16",

--- a/examples/groups/k8s/node2.json
+++ b/examples/groups/k8s/node2.json
@@ -12,7 +12,7 @@
     "ipv4_address": "172.15.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",
-    "k8s_dns_service_ip": "10.3.0.1",
+    "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.22/16",

--- a/examples/groups/k8s/node3.json
+++ b/examples/groups/k8s/node3.json
@@ -12,7 +12,7 @@
     "ipv4_address": "172.15.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",
-    "k8s_dns_service_ip": "10.3.0.1",
+    "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.23/16",


### PR DESCRIPTION
* k8s worker nodes were provisioned with a typo'd DNS service
IP address (10.3.0.1 instead of 10.3.0.10) which caused DNS to
be misconfigured in pods
* Fixes #180