### PR TITLE
examples/k8s: Remove k8s_version from machine metadata

### DIFF
--- a/bootcfg/http/metadata_test.go
+++ b/bootcfg/http/metadata_test.go
@@ -24,7 +24,6 @@ func TestMetadataHandler(t *testing.T) {
 	// - the Group's custom metadata and selectors are served
 	// - key names are upper case
 	expectedData := map[string]string{
-		"K8S_VERSION":  "v1.1.2",
 		"POD_NETWORK":  "10.2.0.0/16",
 		"SERVICE_NAME": "etcd2",
 		"UUID":         "a1b2c3d4",

--- a/bootcfg/storage/testfakes/fixtures.go
+++ b/bootcfg/storage/testfakes/fixtures.go
@@ -11,7 +11,7 @@ var (
 		Name:     "test group",
 		Profile:  "g1h2i3j4",
 		Selector: map[string]string{"uuid": "a1b2c3d4"},
-		Metadata: []byte(`{"k8s_version":"v1.1.2","pod_network":"10.2.0.0/16","service_name":"etcd2"}`),
+		Metadata: []byte(`{"pod_network":"10.2.0.0/16","service_name":"etcd2"}`),
 	}
 
 	// GroupNoMetadata is a Group without any metadata.

--- a/examples/groups/k8s-docker/node1.json
+++ b/examples/groups/k8s-docker/node1.json
@@ -15,7 +15,6 @@
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.17.0.21/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-docker/node2.json
+++ b/examples/groups/k8s-docker/node2.json
@@ -14,7 +14,6 @@
     "k8s_controller_endpoint": "https://172.17.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.17.0.22/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-docker/node3.json
+++ b/examples/groups/k8s-docker/node3.json
@@ -14,7 +14,6 @@
     "k8s_controller_endpoint": "https://172.17.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.17.0.23/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-install/node1.json
+++ b/examples/groups/k8s-install/node1.json
@@ -16,7 +16,6 @@
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s-install/node2.json
+++ b/examples/groups/k8s-install/node2.json
@@ -15,7 +15,6 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s-install/node3.json
+++ b/examples/groups/k8s-install/node3.json
@@ -15,7 +15,6 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node1.json
+++ b/examples/groups/k8s/node1.json
@@ -15,7 +15,6 @@
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node2.json
+++ b/examples/groups/k8s/node2.json
@@ -14,7 +14,6 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node3.json
+++ b/examples/groups/k8s/node3.json
@@ -14,7 +14,6 @@
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
-    "k8s_version": "v1.2.2_coreos.0",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -65,7 +65,7 @@ systemd:
         After=k8s-assets.target
         [Service]
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-        Environment=KUBELET_VERSION={{.k8s_version}}
+        Environment=KUBELET_VERSION=v1.2.2_coreos.0
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers=http://127.0.0.1:8080 \
           --register-schedulable=false \
@@ -122,7 +122,7 @@ storage:
               hostNetwork: true
               containers:
               - name: kube-proxy
-                image: quay.io/coreos/hyperkube:{{.k8s_version}}
+                image: quay.io/coreos/hyperkube:v1.2.2_coreos.0
                 command:
                 - /hyperkube
                 - proxy
@@ -149,7 +149,7 @@ storage:
               hostNetwork: true
               containers:
               - name: kube-apiserver
-                image: quay.io/coreos/hyperkube:{{.k8s_version}}
+                image: quay.io/coreos/hyperkube:v1.2.2_coreos.0
                 command:
                 - /hyperkube
                 - apiserver
@@ -199,7 +199,7 @@ storage:
             spec:
               containers:
               - name: kube-controller-manager
-                image: quay.io/coreos/hyperkube:{{.k8s_version}}
+                image: quay.io/coreos/hyperkube:v1.2.2_coreos.0
                 command:
                 - /hyperkube
                 - controller-manager
@@ -240,7 +240,7 @@ storage:
               hostNetwork: true
               containers:
               - name: kube-scheduler
-                image: quay.io/coreos/hyperkube:{{.k8s_version}}
+                image: quay.io/coreos/hyperkube:v1.2.2_coreos.0
                 command:
                 - /hyperkube
                 - scheduler

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -62,7 +62,7 @@ systemd:
         After=k8s-assets.target
         [Service]
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-        Environment=KUBELET_VERSION={{.k8s_version}}
+        Environment=KUBELET_VERSION=v1.2.2_coreos.0
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers={{.k8s_controller_endpoint}} \
           --register-node=true \
@@ -129,7 +129,7 @@ storage:
               hostNetwork: true
               containers:
               - name: kube-proxy
-                image: quay.io/coreos/hyperkube:{{.k8s_version}}
+                image: quay.io/coreos/hyperkube:v1.2.2_coreos.0
                 command:
                 - /hyperkube
                 - proxy


### PR DESCRIPTION
* Setting k8s_version via metadata gives the impression
it can be bumped and the cluster will operate with the
desired version. In reality, the k8s profiles change in
minor but important ways which we validate between k8s
releases. It should be part of the k8s profile Ignition.
* cc @aaronlevy 