### PR TITLE
Remove 8.8.8.8 from networkd example configs

### DIFF
--- a/Documentation/ignition.md
+++ b/Documentation/ignition.md
@@ -33,7 +33,6 @@ ignition/network.yaml:
             [Network]
             Gateway={{.networkd_gateway}}
             DNS={{.networkd_dns}}
-            DNS=8.8.8.8
             Address={{.networkd_address}}
     {{ if .ssh_authorized_keys }}
     passwd:

--- a/examples/ignition/bootkube-master.yaml
+++ b/examples/ignition/bootkube-master.yaml
@@ -148,7 +148,6 @@ networkd:
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}
-        DNS=8.8.8.8
         Address={{.networkd_address}}
 
 {{ if .ssh_authorized_keys }}

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -104,7 +104,6 @@ networkd:
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}
-        DNS=8.8.8.8
         Address={{.networkd_address}}
 
 {{ if .ssh_authorized_keys }}

--- a/examples/ignition/etcd.yaml
+++ b/examples/ignition/etcd.yaml
@@ -31,7 +31,6 @@ networkd:
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}
-        DNS=8.8.8.8
         Address={{.networkd_address}}
 
 {{ if .ssh_authorized_keys }}

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -638,7 +638,6 @@ networkd:
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}
-        DNS=8.8.8.8
         Address={{.networkd_address}}
 
 {{ if .ssh_authorized_keys }}

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -171,7 +171,6 @@ networkd:
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}
-        DNS=8.8.8.8
         Address={{.networkd_address}}
 
 {{ if .ssh_authorized_keys }}


### PR DESCRIPTION
* Profiles should use only the user-provided DNS endpoint.
Adding 8.8.8.8 can cause inconsistent resolution and in some
setups, 8.8.8.8 is not routable.