### PR TITLE
Update CoreOS version from alpha 983.0.0 to 1032.0.0

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -198,7 +198,7 @@ If you need to serve static assets (e.g. kernel, initrd), `bootcfg` can serve ar
 
     bootcfg.foo/assets/
     └── coreos
-        └── 962.0.0
+        └── 1032.0.0
             ├── coreos_production_pxe.vmlinuz
             └── coreos_production_pxe_image.cpio.gz
         └── 983.0.0

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -24,7 +24,7 @@ The examples statically assign IP addresses for client VMs on the `metal0` CNI b
 
 Download the CoreOS PXE image referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 983.0.0
+    ./scripts/get-coreos alpha 1032.0.0
 
 Use the `bootkube` tool to render Kubernetes manifests and credentials into an output directory.
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -23,7 +23,7 @@ The examples statically assign IP addresses for client VMs on the `metal0` CNI b
 
 Download the CoreOS PXE image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 983.0.0
+    ./scripts/get-coreos alpha 1032.0.0
 
 Generate a root CA and Kubernetes TLS assets for components (`admin`, `apiserver`, `worker`).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,15 +5,15 @@ These examples network boot and provision VMs into CoreOS clusters using `bootcf
 
 | Name       | Description | CoreOS Version | FS | Docs | 
 |------------|-------------|----------------|----|-----------|
-| pxe | CoreOS via iPXE | alpha/983.0.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| grub | CoreOS via GRUB2 Netboot | alpha/983.0.0 | RAM | NA |
-| pxe-disk | CoreOS via iPXE, with a root filesystem | alpha/983.0.0 | Disk | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| etcd, etcd-docker | iPXE boot a 3 node etcd cluster and proxy | alpha/983.0.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
-| etcd-install | Install a 3-node etcd cluster to disk | alpha/983.0.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
-| k8s, k8s-docker | Kubernetes cluster with 1 master and 2 workers, TLS-authentication | alpha/983.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| k8s-install | Install a Kubernetes cluster to disk (1 master) | alpha/983.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/983.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/983.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| pxe | CoreOS via iPXE | alpha/1032.0.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| grub | CoreOS via GRUB2 Netboot | alpha/1032.0.0 | RAM | NA |
+| pxe-disk | CoreOS via iPXE, with a root filesystem | alpha/1032.0.0 | Disk | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| etcd, etcd-docker | iPXE boot a 3 node etcd cluster and proxy | alpha/1032.0.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
+| etcd-install | Install a 3-node etcd cluster to disk | alpha/1032.0.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
+| k8s, k8s-docker | Kubernetes cluster with 1 master and 2 workers, TLS-authentication | alpha/1032.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| k8s-install | Install a Kubernetes cluster to disk (1 master) | alpha/1032.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1032.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1032.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ## Tutorials
 
@@ -21,8 +21,8 @@ Get started running `bootcfg` on your Linux machine to network boot and provisio
 
 * [bootcfg with rkt](../Documentation/getting-started-rkt.md)
 * [bootcfg with Docker](../Documentation/getting-started-docker.md)
-* [Kubernetes](../Documentation/kubernetes.md)
-* [Self-hosted Kubernetes](../Documentation/bootkube.md)
+* [Kubernetes v1.2.2](../Documentation/kubernetes.md)
+* [Self-hosted Kubernetes](../Documentation/bootkube.md) (experimental)
 
 ## Experimental
 

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "983.0.0",
+    "coreos_version": "1032.0.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition"
   }
 }

--- a/examples/groups/etcd-install/install.json
+++ b/examples/groups/etcd-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "983.0.0",
+    "coreos_version": "1032.0.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition"
   }
 }

--- a/examples/groups/k8s-install/install.json
+++ b/examples/groups/k8s-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "983.0.0",
+    "coreos_version": "1032.0.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition"
   }
 }

--- a/examples/profiles/bootkube-master.json
+++ b/examples/profiles/bootkube-master.json
@@ -2,8 +2,8 @@
   "id": "bootkube-master",
   "name": "bootkube Ready Master",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -2,8 +2,8 @@
   "id": "bootkube-worker",
   "name": "bootkube Ready Worker",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/etcd-proxy.json
+++ b/examples/profiles/etcd-proxy.json
@@ -2,8 +2,8 @@
   "id": "etcd-proxy",
   "name": "etcd-proxy",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/etcd.json
+++ b/examples/profiles/etcd.json
@@ -2,8 +2,8 @@
   "id": "etcd",
   "name": "etcd",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/grub.json
+++ b/examples/profiles/grub.json
@@ -2,8 +2,8 @@
   "id": "grub",
   "name": "CoreOS via GRUB2",
   "boot": {
-    "kernel": "(http;bootcfg.foo:8080)/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["(http;bootcfg.foo:8080)/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "(http;bootcfg.foo:8080)/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["(http;bootcfg.foo:8080)/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition",
       "coreos.autologin": "",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -2,8 +2,8 @@
   "id": "install-reboot",
   "name": "Install CoreOS and Reboot",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/install-shutdown.json
+++ b/examples/profiles/install-shutdown.json
@@ -2,8 +2,8 @@
   "id": "install-shutdown",
   "name": "Install CoreOS and Shutdown",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-master-install.json
+++ b/examples/profiles/k8s-master-install.json
@@ -2,8 +2,8 @@
   "id": "k8s-master-install",
   "name": "Kubernetes Master Install",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-master.json
+++ b/examples/profiles/k8s-master.json
@@ -2,8 +2,8 @@
   "id": "k8s-master",
   "name": "Kubernetes Master",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/k8s-worker-install.json
+++ b/examples/profiles/k8s-worker-install.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker-install",
   "name": "Kubernetes Worker Install",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-worker.json
+++ b/examples/profiles/k8s-worker.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/pxe-disk.json
+++ b/examples/profiles/pxe-disk.json
@@ -2,8 +2,8 @@
   "id": "pxe-disk",
   "name": "CoreOS with SSH",
   "boot": {
-    "kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/pxe.json
+++ b/examples/profiles/pxe.json
@@ -3,13 +3,11 @@
 	"name": "CoreOS with SSH",
 	"ignition_id": "ssh.yaml",
 	"boot": {
-		"kernel": "/assets/coreos/983.0.0/coreos_production_pxe.vmlinuz",
-		"initrd": [
-			"/assets/coreos/983.0.0/coreos_production_pxe_image.cpio.gz"
-		],
+		"kernel": "/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
+		"initrd": ["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
 		"cmdline": {
 			"coreos.autologin": "",
-			"coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}\u0026mac=${net0/mac:hexhyp}",
+			"coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
 			"coreos.first_boot": ""
 		}
 	}

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -3,9 +3,9 @@
 # USAGE: ./scripts/get-coreos channel version
 
 CHANNEL=${1:-"alpha"}
-VERSION=${2:-"983.0.0"}
+VERSION=${2:-"1032.0.0"}
 DEST=${PWD}/examples/assets/coreos/$VERSION
-BASE_URL=http://$CHANNEL.release.core-os.net/amd64-usr/$VERSION
+BASE_URL=https://$CHANNEL.release.core-os.net/amd64-usr/$VERSION
 
 # check channel/version exist based on the header response
 curl -s -I $BASE_URL/coreos_production_pxe.vmlinuz | awk '/200/ {found++} /301/ {found++} END { if (found<1) { print "Channel or Version not found"; exit 1 }}'

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -76,6 +76,9 @@ function poweroff {
 
 function destroy {
   for node in ${nodes[@]}; do
+    virsh destroy $node
+  done
+  for node in ${nodes[@]}; do
     virsh undefine $node
   done
   virsh pool-refresh default


### PR DESCRIPTION
* Default example image should be periodically updated and tested against
* Use an OS version with Ignition 0.4.0 so users aren't confused if they try to use the v2.0.0 format
* I've validated all the example clusters