### PR TITLE
bootcfg/client: Fix New error detection and add Close

### DIFF
--- a/bootcfg/client/client.go
+++ b/bootcfg/client/client.go
@@ -1,12 +1,18 @@
 package client
 
 import (
+	"errors"
+
 	"google.golang.org/grpc"
 
 	"github.com/coreos/coreos-baremetal/bootcfg/rpc/rpcpb"
 )
 
-// Config configures a Client.
+var (
+	errNoEndpoints = errors.New("client: No endpoints provided")
+)
+
+// Config configures a Client.go f
 type Config struct {
 	// List of endpoint URLs
 	Endpoints []string
@@ -22,6 +28,9 @@ type Client struct {
 
 // New creates a new Client from the given Config.
 func New(config *Config) (*Client, error) {
+	if len(config.Endpoints) == 0 {
+		return nil, errNoEndpoints
+	}
 	return newClient(config)
 }
 
@@ -39,8 +48,8 @@ func newClient(config *Config) (*Client, error) {
 	return client, nil
 }
 
-// retryDialer attemps to Dial each endpoint until a client connection
-// is established.
+// retryDialer attemps to Dial each endpoint in order to establish a
+// connection.
 func retryDialer(config *Config) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{
 		grpc.WithInsecure(),

--- a/bootcfg/client/client.go
+++ b/bootcfg/client/client.go
@@ -34,6 +34,11 @@ func New(config *Config) (*Client, error) {
 	return newClient(config)
 }
 
+// Close closes the client's connections.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
 func newClient(config *Config) (*Client, error) {
 	conn, err := retryDialer(config)
 	if err != nil {

--- a/bootcfg/client/client_test.go
+++ b/bootcfg/client/client_test.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew_MissingEndpoints(t *testing.T) {
+	cfg := &Config{
+		Endpoints: []string{},
+	}
+	client, err := New(cfg)
+	assert.Nil(t, client)
+	assert.Equal(t, errNoEndpoints, err)
+}

--- a/bootcfg/client/doc.go
+++ b/bootcfg/client/doc.go
@@ -1,2 +1,13 @@
 // Package client provides the bootcfg gRPC client.
+//
+// Create a bootcfg gRPC client using `client.New`:
+//
+//     cfg := &client.Config{
+//       Endpoints: []string{"127.0.0.1:8081"},
+//     }
+//     client, err := client.New(cfg)
+//     defer client.Close()
+//
+// Callers must Close the client after use.
+//
 package client


### PR DESCRIPTION
* Return an error if no endpoints are provided in the client `Config`
* Add a client Close method
* Closes #189 