### PR TITLE
example: Revert ssh Ignition config change

### DIFF
--- a/examples/ignition/ssh.yaml
+++ b/examples/ignition/ssh.yaml
@@ -1,6 +1,5 @@
 ---
-ignition:
-  version: 2.0.0
+ignition_version: 1
 {{ if .ssh_authorized_keys }}
 passwd:
   users:


### PR DESCRIPTION
* Users try to use the latest reference example clusters with
a bootcfg v0.3.0 deployment, which did not yet support Ignition
2.0.0. Wait until closer to v0.4.0 to bump Ignition configs.