### PR TITLE
examples/bootkube: Setup bootkube cluster via on-host bootkube

### DIFF
--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,11 +1,15 @@
 
 # Self-Hosted Kubernetes
 
-The self-hosted Kubernetes examples provision a 3 node cluster with an etcd cluster, flannel, and a special "runonce" host Kublet. The CoreOS [bootkube](https://github.com/coreos/bootkube) reverse-tunnel tool is used to start the kubelet, api server, scheduler, and controller manager as pods which can be managed via kubectl (self-hosted). The `bootkube` example PXE boots and provisions CoreOS nodes for this purpose, while `bootkube-install` does the CoreOS install to disk as well.
+The self-hosted Kubernetes examples provision a 3 node cluster with etcd, flannel, and a special "runonce" host Kublet. The CoreOS [bootkube](https://github.com/coreos/bootkube) tool used to bootstrap kubelet, apiserver, scheduler, and controller-manager pods which can be managed via kubectl. `bootkube start` is run on any controller (master) exactly once to create a temporary control-plane, create Kubernetes components, and stop itself. The `bootkube` examples network boot and provision CoreOS nodes for use with the `bootkube` tool.
+
+## Experimental
+
+Self-hosted Kubernetes is under very active development by CoreOS. We're working on upstreaming the required Hyperkube patches. Be aware that a deployment with a single apiserver cannot tolerate its failure without intervention. We'll be improving this to allow CoreOS auto-updates.
 
 ## Requirements
 
-Ensure that you've gone through the `bootcfg` [Getting Started Guide](getting-started-rkt.md) guide and understand the basics. In particular, you should be able to:
+Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) guide and understand the basics. In particular, you should be able to:
 
 * Use rkt to start `bootcfg`
 * Create a network boot environment with `coreos/dnsmasq`
@@ -26,60 +30,69 @@ Download the CoreOS PXE image referenced in the target [profile](../examples/pro
 
     ./scripts/get-coreos alpha 1032.0.0
 
-Use the `bootkube` tool to render Kubernetes manifests and credentials into an output directory.
+Use the `bootkube` tool to render Kubernetes manifests and credentials into an `--asset-dir`. Later, `bootkube` will schedule these manifests during bootstrapping and the credentials will be used to access your cluster.
 
-    bootkube render --outdir assets --apiserver-cert-ip-addrs=172.15.0.21,10.3.0.1 --api-servers=https://172.15.0.21:6443 --etcd-servers=http://172.15.0.21:2379
+    bootkube render --asset-dir=assets --api-servers=https://172.15.0.21:443 --etcd-servers=http://172.15.0.21:2379 --api-server-alt-names=IP=172.15.0.21
 
-Manually copy the `certificate-authority-data` from the generated `assets/auth/kubeconfig.yaml` file and paste it in each machine group definition in `examples/groups/bootkube` or `examples/groups/bootkube-install` (i.e. `node1json`, `node2.json`, `node3.json`).
+Copy the `certificate-authority-data`, `client-certificate-data`, and `client-key-data` from the generated `assets/auth/kubeconfig` file into each master group definition (e.g. under `examples/groups/bootkube` or `examples/groups/bootkube-install`). Also, add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 
-Manually add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
+    {
+        "profile": "bootkube-worker",
+        "metadata": {
+            "k8s_certificate_authority": "...",
+            "k8s_client_certificate": "...",
+            "k8s_client_key": "...",
+            "ssh_authorized_keys": ["ssh-rsa pub-key-goes-here"]
+        }
+    }
 
 ## Containers
 
-Run the latest `bootcfg` ACI with rkt.
+Run the latest `bootcfg` ACI with rkt and the `bootkube` example (or `bootkube-install`).
 
-    sudo rkt --insecure-options=image run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/bootkube quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
 
-Create the machine groups at runtime (or you could mount them).
-
-    bootcmd --endpoints 172.15.0.2:8081 group create -f examples/groups/bootkube-install/install.json
-    bootcmd --endpoints 172.15.0.2:8081 group create -f examples/groups/bootkube-install/node1.json
-    bootcmd --endpoints 172.15.0.2:8081 group create -f examples/groups/bootkube-install/node2.json
-    bootcmd --endpoints 172.15.0.2:8081 group create -f examples/groups/bootkube-install/node3.json
-
-Check the loaded profiles and groups.
-
-    bootcmd --endpoints 172.15.0.2:8081 group list
-    bootcmd --endpoints 172.15.0.2:8081 profile list
-
-Create a network boot environment with `coreos/dnsmasq`. Finally, create client VMs with `scripts/libvirt` or power-on your physical machines. Client machines should boot and provision themselves.
+Create a network boot environment with `coreos/dnsmasq`. Finally, create client VMs with `scripts/libvirt` or power-on your machines. Client machines should network boot and provision themselves.
 
 Revisit [bootcfg with rkt](getting-started-rkt.md) for help.
 
 ## bootkube
 
-You're ready to use the [bootkube](https://github.com/coreos/bootkube) control plane tool from your laptop. This will run a temporary control plane on your machine and make it available to your cluster via an SSH reverse-tunnel to bootstrap the control plane.
+We're ready to use [bootkube](https://github.com/coreos/bootkube) to create a temporary control plane and bootstrap self-hosted Kubernetes cluster. This is a **one-time** procedure.
 
-    bootkube start --ssh-user=core --ssh-keyfile=${HOME}/.ssh/id_rsa --remote-address=172.15.0.21:22 --remote-etcd-address=172.15.0.21:2379 --manifest-dir=assets/manifests --apiserver-key=assets/tls/apiserver.key --apiserver-cert=assets/tls/apiserver.crt --ca-cert=assets/tls/ca.crt --service-account-key=assets/tls/service-account.key --token-auth-file=assets/auth/token-auth.csv
+Copy the `bootkube` generated assets to any one of the master nodes.
 
-After a few minutes, the kubelet pod started by `bootkube` will take over in place of the host kubelet.
+    scp -r assets core@172.15.0.21:/home/core/assets
+    scp $(which bootkube) core@172.15.0.21:/home/core
+
+Connect to that Kubernetes master node,
+
+    ssh core@172.15.0.21
+
+and run the following commands *on the node*.
+
+    sudo ./bootkube start --asset-dir=/home/core/assets --etcd-server=http://172.15.0.21:2379
+
+Watch the temporary control plane logs until the scheduled kubelet takes over in place of the runonce host kubelet.
 
     I0425 12:38:23.746330   29538 status.go:87] Pod status kubelet: Running
     I0425 12:38:23.746361   29538 status.go:87] Pod status kube-apiserver: Running
     I0425 12:38:23.746370   29538 status.go:87] Pod status kube-scheduler: Running
     I0425 12:38:23.746378   29538 status.go:87] Pod status kube-controller-manager: Running
 
+You may cleanup the `bootkube` assets on the node, but you should keep the copy on your laptop. They contain a `kubeconfig` and may need to be re-used if the last apiserver were to fail and bootstrapping were needed.
+
 ## Verify
 
 [Install kubectl](https://coreos.com/kubernetes/docs/latest/configure-kubectl.html) on your laptop. Use the generated kubeconfig to access the Kubernetes cluster. Verify that the cluster is accessible and that the kubelet, apiserver, scheduler, and controller-manager are running as pods.
 
-    $ kubectl --kubeconfig=assets/auth/kubeconfig.yaml get nodes
+    $ kubectl --kubeconfig=assets/auth/kubeconfig get nodes
     NAME          STATUS    AGE
     172.15.0.21   Ready     3m
     172.15.0.22   Ready     3m
     172.15.0.23   Ready     3m
 
-    $ kubectl --kubeconfig=assets/auth/kubeconfig.yaml get pods --all-namespaces
+    $ kubectl --kubeconfig=assets/auth/kubeconfig get pods --all-namespaces
     NAMESPACE     NAME                            READY     STATUS    RESTARTS   AGE
     kube-system   kube-apiserver-z6f9e            1/1       Running   0          3m
     kube-system   kube-controller-manager-slia7   1/1       Running   0          3m

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -39,6 +39,21 @@ The example manifests use Kubernetes `emptyDir` volumes to back the `bootcfg` Fi
 
 ## Binary
 
+### User/Group
+
+The `bootcfg` service should be run by a non-root user with access to the `bootcfg` data directory (e.g. `/var/lib/bootcfg`). Create a `bootcfg` user and group.
+
+    sudo useradd -U bootcfg
+
+Run the provided script to setup the `bootcfg` data directory.
+
+    sudo ./scripts/setup-data-dir
+
+Add yourself to the `bootcfg` group if you'd like to edit configs directly rather than through the `bootcmd` client.
+
+    SELF=$(whoami)
+    sudo gpasswd --add $SELF bootcfg
+
 ### Prebuilt
 
 Download a prebuilt binary from the Github [releases](https://github.com/coreos/coreos-baremetal/releases).
@@ -72,21 +87,6 @@ Install the `bootcfg` static binary to `/usr/local/bin`.
 
     $ sudo make install
 
-### User/Group
-
-The `bootcfg` service should be run by a non-root user with access to the `bootcfg` data directory (e.g. `/var/lib/bootcfg`). Create a `bootcfg` user and group.
-
-    sudo useradd -U bootcfg
-
-Run the provided script to setup the `bootcfg` data directory.
-
-    sudo ./scripts/setup-data-dir
-
-Add yourself to the `bootcfg` group if you'd like to data by modifying files rather than through the `bootcmd` client.
-
-    SELF=$(whoami)
-    sudo gpasswd --add $SELF bootcfg
-
 ### Run
 
 Run the `bootcfg` server.
@@ -97,7 +97,7 @@ Run the `bootcfg` server.
 
 See [flags and variables](config.md).
 
-## systemd
+### systemd
 
 First, install the `bootcfg` binary from a pre-built binary or from source. Then add and start bootcfg's example systemd unit.
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -5,7 +5,7 @@ The Kubernetes examples provision a 3 node v1.2.4 Kubernetes cluster with one ma
 
 ## Requirements
 
-Ensure that you've gone through the `bootcfg` [Getting Started Guide](getting-started-rkt.md) and understand the basics. In particular, you should be able to:
+Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) guide and understand the basics. In particular, you should be able to:
 
 * Use rkt or Docker to start `bootcfg`
 * Create a network boot environment with `coreos/dnsmasq`

--- a/examples/groups/bootkube-install/node1.json
+++ b/examples/groups/bootkube-install/node1.json
@@ -10,17 +10,20 @@
     "ipv4_address": "172.15.0.21",
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node1",
-    "fleet_metadata": "role=etcd,name=node1",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_master_endpoint": "https://172.15.0.21:6443",
+    "k8s_master_endpoint": "https://172.15.0.21:443",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_secret_token": "token",
-    "k8s_ca_data": "ADD ME",
+    "k8s_certificate_authority": "ADD ME",
+    "k8s_client_certificate": "ADD ME",
+    "k8s_client_key": "ADD ME",
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3"
+    "networkd_name": "ens3",
+    "ssh_authorized_keys": [
+      "ADD ME"
+    ]
   }
 }

--- a/examples/groups/bootkube-install/node2.json
+++ b/examples/groups/bootkube-install/node2.json
@@ -10,16 +10,19 @@
     "ipv4_address": "172.15.0.22",
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node2",
-    "fleet_metadata": "role=etcd,name=node2",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_master_endpoint": "https://172.15.0.21:6443",
+    "k8s_master_endpoint": "https://172.15.0.21:443",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_secret_token": "token",
-    "k8s_ca_data": "ADD ME",
+    "k8s_certificate_authority": "ADD ME",
+    "k8s_client_certificate": "ADD ME",
+    "k8s_client_key": "ADD ME",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3"
+    "networkd_name": "ens3",
+    "ssh_authorized_keys": [
+      "ADD ME"
+    ]
   }
 }

--- a/examples/groups/bootkube-install/node3.json
+++ b/examples/groups/bootkube-install/node3.json
@@ -10,16 +10,19 @@
     "ipv4_address": "172.15.0.23",
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node3",
-    "fleet_metadata": "role=etcd,name=node3",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_master_endpoint": "https://172.15.0.21:6443",
+    "k8s_master_endpoint": "https://172.15.0.21:443",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_secret_token": "token",
-    "k8s_ca_data": "ADD ME",
+    "k8s_certificate_authority": "ADD ME",
+    "k8s_client_certificate": "ADD ME",
+    "k8s_client_key": "ADD ME",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3"
+    "networkd_name": "ens3",
+    "ssh_authorized_keys": [
+      "ADD ME"
+    ]
   }
 }

--- a/examples/groups/bootkube/node1.json
+++ b/examples/groups/bootkube/node1.json
@@ -6,21 +6,24 @@
     "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b"
   },
   "metadata": {
-    "ipv4_address": "172.15.0.21",
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node1",
-    "fleet_metadata": "role=etcd,name=node1",
+    "ipv4_address": "172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_master_endpoint": "https://172.15.0.21:6443",
+    "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
+    "k8s_master_endpoint": "https://172.15.0.21:443",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_secret_token": "token",
-    "k8s_ca_data": "ADD ME",
-    "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
+    "k8s_certificate_authority": "ADD ME",
+    "k8s_client_certificate": "ADD ME",
+    "k8s_client_key": "ADD ME",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
     "networkd_name": "ens3",
-    "pxe": "true"
+    "pxe": "true",
+    "ssh_authorized_keys": [
+      "ADD ME"
+    ]
   }
 }

--- a/examples/groups/bootkube/node2.json
+++ b/examples/groups/bootkube/node2.json
@@ -9,17 +9,20 @@
     "ipv4_address": "172.15.0.22",
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node2",
-    "fleet_metadata": "role=etcd,name=node2",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_master_endpoint": "https://172.15.0.21:6443",
+    "k8s_master_endpoint": "https://172.15.0.21:443",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_secret_token": "token",
-    "k8s_ca_data": "ADD ME",
+    "k8s_certificate_authority": "ADD ME",
+    "k8s_client_certificate": "ADD ME",
+    "k8s_client_key": "ADD ME",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
     "networkd_name": "ens3",
-    "pxe": "true"
+    "pxe": "true",
+    "ssh_authorized_keys": [
+      "ADD ME"
+    ]
   }
 }

--- a/examples/groups/bootkube/node3.json
+++ b/examples/groups/bootkube/node3.json
@@ -9,17 +9,20 @@
     "ipv4_address": "172.15.0.23",
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node3",
-    "fleet_metadata": "role=etcd,name=node3",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_master_endpoint": "https://172.15.0.21:6443",
+    "k8s_master_endpoint": "https://172.15.0.21:443",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
-    "k8s_secret_token": "token",
-    "k8s_ca_data": "ADD ME",
+    "k8s_certificate_authority": "ADD ME",
+    "k8s_client_certificate": "ADD ME",
+    "k8s_client_key": "ADD ME",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
     "networkd_name": "ens3",
-    "pxe": "true"
+    "pxe": "true",
+    "ssh_authorized_keys": [
+      "ADD ME"
+    ]
   }
 }

--- a/examples/ignition/bootkube-master.yaml
+++ b/examples/ignition/bootkube-master.yaml
@@ -22,13 +22,6 @@ systemd:
           contents: |
             [Service]
             ExecStartPre=/opt/init-flannel
-    - name: fleet.service
-      enable: true
-      dropins:
-        - name: 40-fleet-metadata.conf
-          contents: |
-            [Service]
-            Environment="FLEET_METADATA={{.fleet_metadata}}"
     - name: docker.service
       enable: true
       dropins:
@@ -51,11 +44,12 @@ systemd:
           --runonce \
           --runonce-timeout=60s \
           --api-servers={{.k8s_master_endpoint}} \
-          --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --allow-privileged \
           --hostname-override={{.ipv4_address}} \
           --node-labels=master=true \
+          --minimum-container-ttl-duration=3m0s \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         Restart=always
@@ -83,7 +77,7 @@ storage:
       format: "ext4"
   {{end}}
       files:
-        - path: /etc/kubernetes/kubeconfig.yaml
+        - path: /etc/kubernetes/kubeconfig
           mode: 0644
           contents: |
             apiVersion: v1
@@ -92,27 +86,16 @@ storage:
             - name: local
               cluster:
                 server: {{.k8s_master_endpoint}}
-                certificate-authority-data: {{.k8s_ca_data}}
+                certificate-authority-data: {{.k8s_certificate_authority}}
             users:
-            - name: k8s
+            - name: kubelet
               user:
-                token: {{.k8s_secret_token}}
+                client-certificate-data: {{.k8s_client_certificate}}
+                client-key-data: {{.k8s_client_key}}
             contexts:
             - context:
                 cluster: local
-                user: k8s
-        - path: /etc/ssh/sshd_config
-          mode: 0600
-          uid: 0
-          contents: |
-            # Use most defaults for sshd configuration.
-            UsePrivilegeSeparation sandbox
-            Subsystem sftp internal-sftp
-            PermitRootLogin no
-            AllowUsers core
-            PasswordAuthentication no
-            ChallengeResponseAuthentication no
-            GatewayPorts clientspecified
+                user: kubelet
         - path: /opt/init-flannel
           mode: 0544
           contents: |

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -17,13 +17,6 @@ systemd:
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
     - name: flanneld.service
       enable: true
-    - name: fleet.service
-      enable: true
-      dropins:
-        - name: 40-fleet-metadata.conf
-          contents: |
-            [Service]
-            Environment="FLEET_METADATA={{.fleet_metadata}}"
     - name: docker.service
       enable: true
       dropins:
@@ -46,10 +39,11 @@ systemd:
           --runonce \
           --runonce-timeout=60s \
           --api-servers={{.k8s_master_endpoint}} \
-          --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --allow-privileged \
           --hostname-override={{.ipv4_address}} \
+          --minimum-container-ttl-duration=3m0s \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         Restart=always
@@ -77,7 +71,7 @@ storage:
       format: "ext4"
   {{end}}
       files:
-        - path: /etc/kubernetes/kubeconfig.yaml
+        - path: /etc/kubernetes/kubeconfig
           mode: 0644
           contents: |
             apiVersion: v1
@@ -86,15 +80,16 @@ storage:
             - name: local
               cluster:
                 server: {{.k8s_master_endpoint}}
-                certificate-authority-data: {{.k8s_ca_data}}
+                certificate-authority-data: {{.k8s_certificate_authority}}
             users:
-            - name: k8s
+            - name: kubelet
               user:
-                token: {{.k8s_secret_token}}
+                client-certificate-data: {{.k8s_client_certificate}}
+                client-key-data: {{.k8s_client_key}}
             contexts:
             - context:
                 cluster: local
-                user: k8s
+                user: kubelet
 
 networkd:
   units:


### PR DESCRIPTION
* bootkube clusters work with bootkube on-host 5c1efe3ac61e270
* Copy bootkube generated assets and executable to any master
* Change hosts to use kubelet client certificate instead of token
* Update bootkube deployment documentation
* I've tested both the PXE booted and installed to disk bootkube cluster examples

cc @derekparker @aaronlevy 