### PR TITLE
Documentation: More details about Ignition templating

### DIFF
--- a/Documentation/ignition.md
+++ b/Documentation/ignition.md
@@ -3,7 +3,9 @@
 
 Ignition is a system for declaratively provisioning disks from the initramfs, before systemd starts. It runs only on the first boot and handles formatting partitioning, writing files (systemd units, networkd units, dropins, regular files), and configuring users. See the Ignition [docs](https://coreos.com/ignition/docs/latest/) for details.
 
-Ignition template files can be added in the `/var/lib/bootcfg/ignition` directory or in an `ignition` subdirectory of a custom `-data-path`. Template files may contain [Go template](https://golang.org/pkg/text/template/) elements which will be evaluated with Group `metadata` and should render to JSON or YAML (which will be served by `bootcfg` as JSON).
+Ignition configurations are JSON documents, but with bootcfg you may write and maintain YAML templates which will be converted to JSON when requested. Templating allows values to be substituted to facilitate reuse.
+
+Ignition template files can be added in the `/var/lib/bootcfg/ignition` directory or in an `ignition` subdirectory of a custom `-data-path`. Template files may contain [Go template](https://golang.org/pkg/text/template/) elements which will be evaluated with Group `metadata` and should render to JSON or YAML (which will be returned by `bootcfg` as JSON after processing).
 
     /var/lib/bootcfg
      ├── cloud
@@ -18,9 +20,9 @@ Reference an Ignition config in a [Profile](bootcfg.md#profiles). When PXE booti
 
 ## Configs
 
-Here is an example Ignition template for static networking, which will be rendered, with metadata, into YAML and tranformed into machine-friendly JSON.
+Here is an example Ignition template for static networking. This template will be rendered into YAML, using metadata (from a Group) to fill in the template values. Once templated, the YAML is then tranformed into standard JSON. All of this happens at query time, so that when Ignition queries bootcfg the only thing it sees is the final standard JSON output.
 
-ignition/network.tmpl:
+ignition/network.yaml.tmpl:
 
     ---
     ignition_version: 1
@@ -44,7 +46,7 @@ ignition/network.tmpl:
             {{end}}
     {{end}}
 
-Response from `/ignition?mac=address` for a particular machine.
+Below is a response that you would get from making a GET request to `/ignition?mac=address` for a particular machine. As you can see, the file response is in JSON, not YAML, as Ignition is a JSON format. You can also see that the templated values such as `{{.networkd_name}}` has been filled in.
 
     {
       "ignitionVersion": 1,
@@ -63,7 +65,7 @@ Response from `/ignition?mac=address` for a particular machine.
 
 Note that rendered Ignition does **not** allow variables - the response has been fully rendered with `metadata` for the requesting machine.
 
-Ignition configs can be provided directly as JSON as well (`.ign` or `.ignition`). This is useful for simple cases or if you prefer to use your own templating solution to generate Ignition configs.
+Ignition configs can be provided directly as JSON as well (`.ign` or `.ignition`). This is useful for simple cases or if you prefer to use your own templating solution to generate Ignition configs. This would be very similar to running your own webserver to hosting Ignition configs.
 
 ignition/run-hello.ign:
 


### PR DESCRIPTION
More explicitly write about the difference between an Ignition template, and an Ignition config file.

This may be slightly more redundant but I think it should help clarify common questions about Ignition files being written in YAML and the connection between metadata coming from a Group definition and how that gets used with an Ignition template.