### PR TITLE
examples: Select by MAC, remove networkd_name metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Allow Ignition 2.0.0 JSON and YAML template files
 * Stop requiring Ignition templates to use file extensions (#176)
-* Show `bootcfg` version at the home path `/`
+* Show `bootcfg` message at the home path `/`
 * Fix http package log messages and increase request logging (#173)
 * Add/improve rkt, Docker, Kubernetes, and binary/systemd deployment docs
 

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -155,7 +155,7 @@ Finds the matching machine group and renders the selectors and metadata as a `pl
     NETWORKD_NAME=ens3
     ETCD_NAME=node1
     FLEET_METADATA=role=etcd,name=node1
-    UUID=16e7d8a7-bfa9-428b-9117-363341bb330b
+    MAC=52:54:00:a1:9c:ae
     ETCD_INITIAL_CLUSTER=node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380
     NETWORKD_DNS=172.15.0.3
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -43,9 +43,9 @@ Alternately, run the most recent tagged `bootcfg` [release](https://github.com/c
 
 Take a look at the [etcd groups](../examples/groups/etcd-docker) to get an idea of how machines are mapped to Profiles. Explore some endpoints port mapped to localhost:8080.
 
-* [node1's ipxe](http://127.0.0.1:8080/ipxe?uuid=16e7d8a7-bfa9-428b-9117-363341bb330b)
-* [node1's Ignition](http://127.0.0.1:8080/ignition?uuid=16e7d8a7-bfa9-428b-9117-363341bb330b)
-* [node1's Metadata](http://127.0.0.1:8080/metadata?uuid=16e7d8a7-bfa9-428b-9117-363341bb330b)
+* [node1's ipxe](http://127.0.0.1:8080/ipxe?mac=52:54:00:a1:9c:ae)
+* [node1's Ignition](http://127.0.0.1:8080/ignition?mac=52:54:00:a1:9c:ae)
+* [node1's Metadata](http://127.0.0.1:8080/metadata?mac=52:54:00:a1:9c:ae)
 
 ## Network
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -74,9 +74,9 @@ If you get an error about the IP assignment, garbage collect old pods.
 
 Take a look at the [etcd groups](../examples/groups/etcd) to get an idea of how machines are mapped to Profiles. Explore some endpoints exposed by the service.
 
-* [node1's ipxe](http://172.15.0.2:8080/ipxe?uuid=16e7d8a7-bfa9-428b-9117-363341bb330b)
-* [node1's Ignition](http://172.15.0.2:8080/ignition?uuid=16e7d8a7-bfa9-428b-9117-363341bb330b)
-* [node1's Metadata](http://172.15.0.2:8080/metadata?uuid=16e7d8a7-bfa9-428b-9117-363341bb330b)
+* [node1's ipxe](http://172.15.0.2:8080/ipxe?mac=52:54:00:a1:9c:ae)
+* [node1's Ignition](http://172.15.0.2:8080/ignition?mac=52:54:00:a1:9c:ae)
+* [node1's Metadata](http://172.15.0.2:8080/metadata?mac=52:54:00:a1:9c:ae)
 
 ## Network
 

--- a/Documentation/ignition.md
+++ b/Documentation/ignition.md
@@ -26,10 +26,10 @@ ignition/network.tmpl:
     ignition_version: 1
     networkd:
       units:
-        - name: 00-{{.networkd_name}}.network
+        - name: 10-static.network
           contents: |
             [Match]
-            Name={{.networkd_name}}
+            MACAddress={{.mac}}
             [Network]
             Gateway={{.networkd_gateway}}
             DNS={{.networkd_dns}}

--- a/examples/groups/bootkube-install/node1.json
+++ b/examples/groups/bootkube-install/node1.json
@@ -3,7 +3,7 @@
   "name": "Master Node",
   "profile": "bootkube-master",
   "selector": {
-    "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b",
+    "mac": "52:54:00:a1:9c:ae",
     "os": "installed"
   },
   "metadata": {
@@ -21,7 +21,6 @@
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
     "ssh_authorized_keys": [
       "ADD ME"
     ]

--- a/examples/groups/bootkube-install/node2.json
+++ b/examples/groups/bootkube-install/node2.json
@@ -3,7 +3,7 @@
   "name": "Worker Node",
   "profile": "bootkube-worker",
   "selector": {
-    "uuid": "264cd073-ca62-44b3-98c0-50aad5b5f819",
+    "mac": "52:54:00:b2:2f:86",
     "os": "installed"
   },
   "metadata": {
@@ -19,10 +19,6 @@
     "k8s_client_key": "ADD ME",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
-    "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
-    "ssh_authorized_keys": [
-      "ADD ME"
-    ]
+    "networkd_gateway": "172.15.0.1"
   }
 }

--- a/examples/groups/bootkube-install/node3.json
+++ b/examples/groups/bootkube-install/node3.json
@@ -3,7 +3,7 @@
   "name": "Worker Node",
   "profile": "bootkube-worker",
   "selector": {
-    "uuid": "39d2e747-2648-4d68-ae92-bbc70b245055",
+    "mac": "52:54:00:c3:61:77",
     "os": "installed"
   },
   "metadata": {
@@ -19,10 +19,6 @@
     "k8s_client_key": "ADD ME",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
-    "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
-    "ssh_authorized_keys": [
-      "ADD ME"
-    ]
+    "networkd_gateway": "172.15.0.1"
   }
 }

--- a/examples/groups/bootkube/node1.json
+++ b/examples/groups/bootkube/node1.json
@@ -3,7 +3,7 @@
   "name": "Master Node",
   "profile": "bootkube-master",
   "selector": {
-    "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b"
+    "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
@@ -20,7 +20,6 @@
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
     "pxe": "true",
     "ssh_authorized_keys": [
       "ADD ME"

--- a/examples/groups/bootkube/node2.json
+++ b/examples/groups/bootkube/node2.json
@@ -3,7 +3,7 @@
   "name": "Worker Node",
   "profile": "bootkube-worker",
   "selector": {
-    "uuid": "264cd073-ca62-44b3-98c0-50aad5b5f819"
+    "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
     "ipv4_address": "172.15.0.22",
@@ -19,10 +19,6 @@
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
-    "pxe": "true",
-    "ssh_authorized_keys": [
-      "ADD ME"
-    ]
+    "pxe": "true"
   }
 }

--- a/examples/groups/bootkube/node3.json
+++ b/examples/groups/bootkube/node3.json
@@ -3,7 +3,7 @@
   "name": "Worker Node",
   "profile": "bootkube-worker",
   "selector": {
-    "uuid": "39d2e747-2648-4d68-ae92-bbc70b245055"
+    "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
     "ipv4_address": "172.15.0.23",
@@ -19,10 +19,6 @@
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
-    "pxe": "true",
-    "ssh_authorized_keys": [
-      "ADD ME"
-    ]
+    "pxe": "true"
   }
 }

--- a/examples/groups/etcd-docker/default.json
+++ b/examples/groups/etcd-docker/default.json
@@ -4,9 +4,6 @@
   "profile": "etcd-proxy",
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
-    "fleet_metadata": "role=etcd-proxy",
-    "networkd_dns": "172.17.0.3",
-    "networkd_gateway": "172.17.0.1",
-    "networkd_name": "ens3"
+    "fleet_metadata": "role=etcd-proxy"
   }
 }

--- a/examples/groups/etcd-docker/node1.json
+++ b/examples/groups/etcd-docker/node1.json
@@ -3,7 +3,7 @@
   "name": "etcd Node 1",
   "profile": "etcd",
   "selector": {
-    "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b"
+    "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
@@ -12,7 +12,6 @@
     "ipv4_address": "172.17.0.21",
     "networkd_address": "172.17.0.21/16",
     "networkd_dns": "172.17.0.3",
-    "networkd_gateway": "172.17.0.1",
-    "networkd_name": "ens3"
+    "networkd_gateway": "172.17.0.1"
   }
 }

--- a/examples/groups/etcd-docker/node2.json
+++ b/examples/groups/etcd-docker/node2.json
@@ -3,7 +3,7 @@
   "name": "etcd Node 2",
   "profile": "etcd",
   "selector": {
-    "uuid": "264cd073-ca62-44b3-98c0-50aad5b5f819"
+    "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
@@ -12,7 +12,6 @@
     "ipv4_address": "172.17.0.22",
     "networkd_address": "172.17.0.22/16",
     "networkd_dns": "172.17.0.3",
-    "networkd_gateway": "172.17.0.1",
-    "networkd_name": "ens3"
+    "networkd_gateway": "172.17.0.1"
   }
 }

--- a/examples/groups/etcd-docker/node3.json
+++ b/examples/groups/etcd-docker/node3.json
@@ -3,7 +3,7 @@
   "name": "etcd Node 3",
   "profile": "etcd",
   "selector": {
-    "uuid": "39d2e747-2648-4d68-ae92-bbc70b245055"
+    "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
@@ -12,7 +12,6 @@
     "ipv4_address": "172.17.0.23",
     "networkd_address": "172.17.0.23/16",
     "networkd_dns": "172.17.0.3",
-    "networkd_gateway": "172.17.0.1",
-    "networkd_name": "ens3"
+    "networkd_gateway": "172.17.0.1"
   }
 }

--- a/examples/groups/etcd-install/node1.json
+++ b/examples/groups/etcd-install/node1.json
@@ -3,12 +3,11 @@
   "name": "etcd Node 1",
   "profile": "etcd",
   "selector": {
-    "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b",
+    "mac": "52:54:00:a1:9c:ae",
     "os": "installed"
   },
   "metadata": {
     "ipv4_address": "172.15.0.21",
-    "networkd_name": "ens3",
     "networkd_gateway": "172.15.0.1",
     "networkd_dns": "172.15.0.3",
     "networkd_address": "172.15.0.21/16",

--- a/examples/groups/etcd-install/node2.json
+++ b/examples/groups/etcd-install/node2.json
@@ -3,12 +3,11 @@
   "name": "etcd Node 2",
   "profile": "etcd",
   "selector": {
-    "uuid": "264cd073-ca62-44b3-98c0-50aad5b5f819",
+    "mac": "52:54:00:b2:2f:86",
     "os": "installed"
   },
   "metadata": {
     "ipv4_address": "172.15.0.22",
-    "networkd_name": "ens3",
     "networkd_gateway": "172.15.0.1",
     "networkd_dns": "172.15.0.3",
     "networkd_address": "172.15.0.22/16",

--- a/examples/groups/etcd-install/node3.json
+++ b/examples/groups/etcd-install/node3.json
@@ -3,12 +3,11 @@
   "name": "etcd Node 3",
   "profile": "etcd",
   "selector": {
-    "uuid": "39d2e747-2648-4d68-ae92-bbc70b245055",
+    "mac": "52:54:00:c3:61:77",
     "os": "installed"
   },
   "metadata": {
     "ipv4_address": "172.15.0.23",
-    "networkd_name": "ens3",
     "networkd_gateway": "172.15.0.1",
     "networkd_dns": "172.15.0.3",
     "networkd_address": "172.15.0.23/16",

--- a/examples/groups/etcd-install/proxies.json
+++ b/examples/groups/etcd-install/proxies.json
@@ -6,9 +6,6 @@
     "os": "installed"
   },
   "metadata": {
-    "networkd_name": "ens3",
-    "networkd_gateway": "172.15.0.1",
-    "networkd_dns": "172.15.0.3",
     "fleet_metadata": "role=etcd-proxy",
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
   }

--- a/examples/groups/etcd/default.json
+++ b/examples/groups/etcd/default.json
@@ -3,9 +3,6 @@
   "name": "default",
   "profile": "etcd-proxy",
   "metadata": {
-    "networkd_name": "ens3",
-    "networkd_gateway": "172.15.0.1",
-    "networkd_dns": "172.15.0.3",
     "fleet_metadata": "role=etcd-proxy",
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
   }

--- a/examples/groups/etcd/node1.json
+++ b/examples/groups/etcd/node1.json
@@ -3,11 +3,10 @@
   "name": "etcd Node 1",
   "profile": "etcd",
   "selector": {
-    "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b"
+    "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
     "ipv4_address": "172.15.0.21",
-    "networkd_name": "ens3",
     "networkd_gateway": "172.15.0.1",
     "networkd_dns": "172.15.0.3",
     "networkd_address": "172.15.0.21/16",

--- a/examples/groups/etcd/node2.json
+++ b/examples/groups/etcd/node2.json
@@ -3,11 +3,10 @@
   "name": "etcd Node 2",
   "profile": "etcd",
   "selector": {
-    "uuid": "264cd073-ca62-44b3-98c0-50aad5b5f819"
+    "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
     "ipv4_address": "172.15.0.22",
-    "networkd_name": "ens3",
     "networkd_gateway": "172.15.0.1",
     "networkd_dns": "172.15.0.3",
     "networkd_address": "172.15.0.22/16",

--- a/examples/groups/etcd/node3.json
+++ b/examples/groups/etcd/node3.json
@@ -3,11 +3,10 @@
   "name": "etcd Node 3",
   "profile": "etcd",
   "selector": {
-    "uuid": "39d2e747-2648-4d68-ae92-bbc70b245055"
+    "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
     "ipv4_address": "172.15.0.23",
-    "networkd_name": "ens3",
     "networkd_gateway": "172.15.0.1",
     "networkd_dns": "172.15.0.3",
     "networkd_address": "172.15.0.23/16",

--- a/examples/groups/k8s-docker/node1.json
+++ b/examples/groups/k8s-docker/node1.json
@@ -3,7 +3,7 @@
   "name": "Master Node",
   "profile": "k8s-master",
   "selector": {
-    "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b"
+    "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
@@ -18,7 +18,6 @@
     "networkd_address": "172.17.0.21/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",
-    "networkd_name": "ens3",
     "pxe": "true"
   }
 }

--- a/examples/groups/k8s-docker/node2.json
+++ b/examples/groups/k8s-docker/node2.json
@@ -3,7 +3,7 @@
   "name": "Worker 1",
   "profile": "k8s-worker",
   "selector": {
-    "uuid": "264cd073-ca62-44b3-98c0-50aad5b5f819"
+    "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
@@ -17,7 +17,6 @@
     "networkd_address": "172.17.0.22/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",
-    "networkd_name": "ens3",
     "pxe": "true"
   }
 }

--- a/examples/groups/k8s-docker/node3.json
+++ b/examples/groups/k8s-docker/node3.json
@@ -3,7 +3,7 @@
   "name": "Worker 2",
   "profile": "k8s-worker",
   "selector": {
-    "uuid": "39d2e747-2648-4d68-ae92-bbc70b245055"
+    "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
@@ -17,7 +17,6 @@
     "networkd_address": "172.17.0.23/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",
-    "networkd_name": "ens3",
     "pxe": "true"
   }
 }

--- a/examples/groups/k8s-install/node1.json
+++ b/examples/groups/k8s-install/node1.json
@@ -4,7 +4,7 @@
   "profile": "k8s-master-install",
   "selector": {
     "os": "installed",
-    "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b"
+    "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
@@ -18,7 +18,6 @@
     "k8s_service_ip_range": "10.3.0.0/24",
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
-    "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3"
+    "networkd_gateway": "172.15.0.1"
   }
 }

--- a/examples/groups/k8s-install/node2.json
+++ b/examples/groups/k8s-install/node2.json
@@ -4,7 +4,7 @@
   "profile": "k8s-worker-install",
   "selector": {
     "os": "installed",
-    "uuid": "264cd073-ca62-44b3-98c0-50aad5b5f819"
+    "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
@@ -17,7 +17,6 @@
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
-    "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3"
+    "networkd_gateway": "172.15.0.1"
   }
 }

--- a/examples/groups/k8s-install/node3.json
+++ b/examples/groups/k8s-install/node3.json
@@ -4,7 +4,7 @@
   "profile": "k8s-worker-install",
   "selector": {
     "os": "installed",
-    "uuid": "39d2e747-2648-4d68-ae92-bbc70b245055"
+    "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
@@ -17,7 +17,6 @@
     "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
-    "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3"
+    "networkd_gateway": "172.15.0.1"
   }
 }

--- a/examples/groups/k8s/node1.json
+++ b/examples/groups/k8s/node1.json
@@ -3,7 +3,7 @@
   "name": "Master Node",
   "profile": "k8s-master",
   "selector": {
-    "uuid": "16e7d8a7-bfa9-428b-9117-363341bb330b"
+    "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
@@ -18,7 +18,6 @@
     "networkd_address": "172.15.0.21/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
     "pxe": "true"
   }
 }

--- a/examples/groups/k8s/node2.json
+++ b/examples/groups/k8s/node2.json
@@ -3,7 +3,7 @@
   "name": "Worker 1",
   "profile": "k8s-worker",
   "selector": {
-    "uuid": "264cd073-ca62-44b3-98c0-50aad5b5f819"
+    "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
@@ -17,7 +17,6 @@
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
     "pxe": "true"
   }
 }

--- a/examples/groups/k8s/node3.json
+++ b/examples/groups/k8s/node3.json
@@ -3,7 +3,7 @@
   "name": "Worker 2",
   "profile": "k8s-worker",
   "selector": {
-    "uuid": "39d2e747-2648-4d68-ae92-bbc70b245055"
+    "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
@@ -17,7 +17,6 @@
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",
-    "networkd_name": "ens3",
     "pxe": "true"
   }
 }

--- a/examples/ignition/bootkube-master.yaml
+++ b/examples/ignition/bootkube-master.yaml
@@ -125,10 +125,10 @@ storage:
             init_flannel
 networkd:
   units:
-    - name: 00-{{.networkd_name}}.network
+    - name: 10-static.network
       contents: |
         [Match]
-        Name={{.networkd_name}}
+        MACAddress={{.mac}}
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -93,10 +93,10 @@ storage:
 
 networkd:
   units:
-    - name: 00-{{.networkd_name}}.network
+    - name: 10-static.network
       contents: |
         [Match]
-        Name={{.networkd_name}}
+        MACAddress={{.mac}}
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}

--- a/examples/ignition/etcd.yaml
+++ b/examples/ignition/etcd.yaml
@@ -25,10 +25,10 @@ systemd:
 
 networkd:
   units:
-    - name: 00-{{.networkd_name}}.network
+    - name: 10-static.network
       contents: |
         [Match]
-        Name={{.networkd_name}}
+        MACAddress={{.mac}}
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -632,10 +632,10 @@ storage:
             
 networkd:
   units:
-    - name: 00-{{.networkd_name}}.network
+    - name: 1-static.network
       contents: |
         [Match]
-        Name={{.networkd_name}}
+        MACAddress={{.mac}}
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -165,10 +165,10 @@ storage:
 
 networkd:
   units:
-    - name: 00-{{.networkd_name}}.network
+    - name: 10-static.network
       contents: |
         [Match]
-        Name={{.networkd_name}}
+        MACAddress={{.mac}}
         [Network]
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}


### PR DESCRIPTION
* Match machines by MAC address in reference example clusters
* Re-use the MAC address to assign static networkd configs where needed (for etcd and k8s)
* UUID is useful to uniquely identify a machine (unlike MAC) but many users had difficulty finding the network device name to use in static networkd configs. Selecting by MAC reduces the potential for user error here.

I've validated these clusters, including the docker ones. @joeatwork 