### PR TITLE
bootcfg/http: Log errors for missing template metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,15 +6,17 @@
 * Stop requiring Ignition templates to use file extensions (#176)
 * Show `bootcfg` message at the home path `/`
 * Fix http package log messages and increase request logging (#173)
+* Error when an Ignition/Cloud-config template is rendered with a machine Group which is missing a metadata value. Previously, missing values defaulted to "no value" (#210)
 * Add/improve rkt, Docker, Kubernetes, and binary/systemd deployment docs
 
 #### Examples
 
+* Add self-hosted Kubernetes example (PXE boot or install to disk)
+* Add `create-uefi` subcommand to `scripts/libvirt` for UEFI/GRUB testing
 * Updated Kubernetes examples to v1.2.4
 * Remove 8.8.8.8 from networkd example Ignition configs (#184)
 * Fix a bug in the k8s example k8s-certs@.service file check (#156)
-* Add self-hosted Kubernetes example (PXE boot or install to disk)
-* Add `create-uefi` subcommand to `scripts/libvirt` for UEFI/GRUB testing
+* Match machines by MAC address in examples to simplify networkd device matching (#209)
 
 ## v0.3.0 (2016-04-14)
 

--- a/bootcfg/http/context.go
+++ b/bootcfg/http/context.go
@@ -3,8 +3,9 @@ package http
 import (
 	"errors"
 
-	"github.com/coreos/coreos-baremetal/bootcfg/storage/storagepb"
 	"golang.org/x/net/context"
+
+	"github.com/coreos/coreos-baremetal/bootcfg/storage/storagepb"
 )
 
 // unexported key prevents collisions

--- a/bootcfg/http/context_test.go
+++ b/bootcfg/http/context_test.go
@@ -3,9 +3,10 @@ package http
 import (
 	"testing"
 
-	"github.com/coreos/coreos-baremetal/bootcfg/storage/storagepb"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
+
+	"github.com/coreos/coreos-baremetal/bootcfg/storage/storagepb"
 )
 
 func TestContextProfile(t *testing.T) {

--- a/bootcfg/http/ignition.go
+++ b/bootcfg/http/ignition.go
@@ -3,7 +3,6 @@ package http
 import (
 	"bytes"
 	"encoding/json"
-	"gopkg.in/yaml.v2"
 	"net/http"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	ignitionV1 "github.com/coreos/ignition/config/v1"
 	ignitionV1Types "github.com/coreos/ignition/config/v1/types"
 	"golang.org/x/net/context"
+	"gopkg.in/yaml.v2"
 
 	"github.com/coreos/coreos-baremetal/bootcfg/server"
 	pb "github.com/coreos/coreos-baremetal/bootcfg/server/serverpb"

--- a/bootcfg/http/serialize.go
+++ b/bootcfg/http/serialize.go
@@ -31,7 +31,7 @@ func renderJSON(w http.ResponseWriter, v interface{}) {
 }
 
 func renderTemplate(w io.Writer, data interface{}, contents ...string) (err error) {
-	tmpl := template.New("")
+	tmpl := template.New("").Option("missingkey=error")
 	for _, content := range contents {
 		tmpl, err = tmpl.Parse(content)
 		if err != nil {

--- a/examples/ignition/bootkube-master.yaml
+++ b/examples/ignition/bootkube-master.yaml
@@ -58,7 +58,7 @@ systemd:
         WantedBy=multi-user.target
 
 storage:
-  {{ if .pxe }}
+  {{ if index . "pxe" }}
   disks:
     - device: /dev/sda
       wipe_table: true
@@ -134,7 +134,7 @@ networkd:
         DNS={{.networkd_dns}}
         Address={{.networkd_address}}
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -52,7 +52,7 @@ systemd:
         WantedBy=multi-user.target
 
 storage:
-  {{ if .pxe }}
+  {{ if index . "pxe" }}
   disks:
     - device: /dev/sda
       wipe_table: true
@@ -102,7 +102,7 @@ networkd:
         DNS={{.networkd_dns}}
         Address={{.networkd_address}}
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/etcd-aws.yaml
+++ b/examples/ignition/etcd-aws.yaml
@@ -21,7 +21,7 @@ systemd:
               --discovery={{.etcd_discovery}}
     - name: fleet.service
       enable: true
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/etcd-proxy.yaml
+++ b/examples/ignition/etcd-proxy.yaml
@@ -19,7 +19,7 @@ systemd:
             [Service]
             Environment="FLEET_METADATA={{.fleet_metadata}}"
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/etcd.yaml
+++ b/examples/ignition/etcd.yaml
@@ -34,7 +34,7 @@ networkd:
         DNS={{.networkd_dns}}
         Address={{.networkd_address}}
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/format-disk.yaml
+++ b/examples/ignition/format-disk.yaml
@@ -15,7 +15,7 @@ storage:
         options:
           - "-LROOT"
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/install-reboot.yaml
+++ b/examples/ignition/install-reboot.yaml
@@ -17,7 +17,7 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/install-shutdown.yaml
+++ b/examples/ignition/install-shutdown.yaml
@@ -17,7 +17,7 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -93,7 +93,7 @@ systemd:
         WantedBy=multi-user.target
 
 storage:
-  {{ if .pxe }}
+  {{ if index . "pxe" }}
   disks:
     - device: /dev/sda
       wipe_table: true
@@ -641,7 +641,7 @@ networkd:
         DNS={{.networkd_dns}}
         Address={{.networkd_address}}
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -81,7 +81,7 @@ systemd:
         WantedBy=multi-user.target
 
 storage:
-  {{ if .pxe }}
+  {{ if index . "pxe" }}
   disks:
     - device: /dev/sda
       wipe_table: true
@@ -174,7 +174,7 @@ networkd:
         DNS={{.networkd_dns}}
         Address={{.networkd_address}}
 
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core

--- a/examples/ignition/ssh.yaml
+++ b/examples/ignition/ssh.yaml
@@ -1,6 +1,6 @@
 ---
 ignition_version: 1
-{{ if .ssh_authorized_keys }}
+{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core


### PR DESCRIPTION
* Rendering an Ignition config or cloud-config template with machine group metadata will log an error if a metadata value is missing.
* Previously, the default missing value was "no value"
* Closes #190 

@mischief 