### PR TITLE
examples/k8s: Update apiserver admission-control

### DIFF
--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -160,7 +160,7 @@ storage:
                 - --service-cluster-ip-range={{.k8s_service_ip_range}}
                 - --secure-port=443
                 - --advertise-address={{.ipv4_address}}
-                - --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+                - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
                 - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
                 - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
                 - --client-ca-file=/etc/kubernetes/ssl/ca.pem


### PR DESCRIPTION
* Update to k8s 1.2.0 recommended admission-control settings
* Improves conformance test results (validate this and report in #71 )
* Upstream recommendation: http://kubernetes.io/docs/admin/admission-controllers/
* Related: https://github.com/coreos/coreos-kubernetes/issues/497

cc @aaronlevy 