### PR TITLE
Update dnsmasq ACI retained capabilities

### DIFF
--- a/contrib/dnsmasq/build-aci
+++ b/contrib/dnsmasq/build-aci
@@ -33,7 +33,7 @@ acbuild --debug port add dhcp udp 67
 acbuild --debug port add dns udp 53
 
 # Elevate network admin capabilities
-echo "{\"set\": [\"CAP_NET_ADMIN\"]}" | acbuild --debug isolator add os/linux/capabilities-retain-set -
+echo "{\"set\": [\"CAP_NET_ADMIN\", \"CAP_NET_BIND_SERVICE\"]}" | acbuild --debug isolator add os/linux/capabilities-retain-set -
 
 # Set the exec command
 acbuild --debug set-exec -- /usr/sbin/dnsmasq -d

--- a/contrib/dnsmasq/build-aci
+++ b/contrib/dnsmasq/build-aci
@@ -16,7 +16,7 @@ trap "{ export EXT=$?; acbuild --debug end && exit $EXT; }" EXIT
 acbuild --debug set-name coreos.com/dnsmasq
 
 # Add a version label
-acbuild --debug label add version v0.2.0
+acbuild --debug label add version v0.3.0
 
 # Add alpine base dependency
 acbuild --debug dep add quay.io/coreos/alpine-sh
@@ -33,7 +33,7 @@ acbuild --debug port add dhcp udp 67
 acbuild --debug port add dns udp 53
 
 # Elevate network admin capabilities
-echo "{\"set\": [\"CAP_NET_ADMIN\", \"CAP_NET_BIND_SERVICE\"]}" | acbuild --debug isolator add os/linux/capabilities-retain-set -
+echo "{\"set\": [\"CAP_NET_ADMIN\", \"CAP_NET_BIND_SERVICE\", \"CAP_SETGID\", \"CAP_SETUID\", \"CAP_NET_RAW\"]}" | acbuild --debug isolator add os/linux/capabilities-retain-set -
 
 # Set the exec command
 acbuild --debug set-exec -- /usr/sbin/dnsmasq -d


### PR DESCRIPTION
On rkt v1.6,

```
sudo rkt run coreos.com/dnsmasq:v0.2.0 -- -d
sudo rkt run coreos.com/dnsmasq:v0.2.0                             # as a daemon
dnsmasq[5]: dnsmasq: failed to bind DHCP server socket: Permission denied
```

* Original issue https://github.com/coreos/rkt/issues/2706
* Original PR: https://github.com/coreos/coreos-baremetal/pull/218

We'll need to build, upload, and sign a coreos.com/dnsmasq:v0.3.0. The version isn't particularly significant, they just need to match some coreos-baremetal release since that's where coreos.com serves from and I'd rather not override v0.2.0.

@iaguis