### PR TITLE
*: Use agnostic Makefile, stop creating empty env file

### DIFF
--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -7,8 +7,8 @@ Configuration arguments can be provided as flags or as environment variables.
 |------|----------|---------|---------|
 | -address | BOOTCFG_ADDRESS | 127.0.0.1:8080 | 0.0.0.0:8080 |
 | -log-level | BOOTCFG_LOG_LEVEL | info | critical, error, warning, notice, info, debug |
-| -data-path | BOOTCFG_DATA_PATH | /var/lib/bootcfg | ~/.bootcfg |
-| -assets-path | BOOTCFG_ASSETS_PATH | /var/lib/bootcfg/assets | ~/.bootcfg/assets |
+| -data-path | BOOTCFG_DATA_PATH | /var/lib/bootcfg | ./examples |
+| -assets-path | BOOTCFG_ASSETS_PATH | /var/lib/bootcfg/assets | ./examples/assets |
 | -rpc-address | BOOTCFG_RPC_ADDRESS | (RPC server disabled) | 127.0.0.1:8081 |
 | -key-ring-path | BOOTCFG_KEY_RING_PATH | (no key ring) | ~/.secrets/vault/bootcfg/secring.gpg |
 | (no flag) | BOOTCFG_PASSPHRASE | (no passphrase) | "secret passphrase" |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 
 BIN_DIR=/usr/local/bin
-DATA_DIR=/var/lib/bootcfg
-ENV_FILE=/etc/bootcfg.env
 
 all: build
 
@@ -12,7 +10,6 @@ test:
 	./test
 
 install:
-	touch ${ENV_FILE}
 	cp bin/bootcfg $(BIN_DIR)
 	cp bin/bootcmd $(BIN_DIR)
 	@echo "**************"

--- a/contrib/systemd/bootcfg.service
+++ b/contrib/systemd/bootcfg.service
@@ -6,7 +6,6 @@ Documentation=https://github.com/coreos/coreos-baremetal
 Type=simple
 User=bootcfg
 Group=bootcfg
-EnvironmentFile=/etc/bootcfg.env
 ExecStart=/usr/local/bin/bootcfg -address=0.0.0.0:8080 -log-level=debug
 
 # systemd.exec


### PR DESCRIPTION
* systemd users can use /etc/bootcfg.env if they choose to use environment files