### PR TITLE
examples: Optionally skip networkd configuration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,3 +40,13 @@ Most examples allow `ssh_authorized_keys` to be added for the `core` user as mac
             "ssh_authorized_keys": ["ssh-rsa pub-key-goes-here"]
         }
     }
+
+## Conditional Variables
+
+### "pxe"
+
+Some examples check the `pxe` variable to determine whether to create a `/dev/sda1` filesystem and partition for PXEing with `root=/dev/sda1` ("pxe":"true") or to write files to the existing filesystem on `/dev/disk/by-label/ROOT` ("pxe":"false").
+
+### "skip_networkd"
+
+Some examples (mainly Kubernetes examples) check the `skip_networkd` variable to determine whether to skip configuring networkd. When `true`, the default networkd config is used, which uses DCHP to setup networking. Use this if you've pre-configured static IP mappings for Kubernetes nodes in your DHCP server. Otherwise, `networkd_address`, `networkd_dns`, and `networkd_gateway` machine metadata are used to populate a networkd configuration on each host.

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -629,7 +629,8 @@ storage:
             echo "K8S: Heapster addon"
             curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-deployment.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments" > /dev/null
             curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
-            
+
+{{ if not (index . "skip_networkd") }}
 networkd:
   units:
     - name: 1-static.network
@@ -640,6 +641,7 @@ networkd:
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}
         Address={{.networkd_address}}
+{{end}}
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -163,6 +163,7 @@ storage:
             FLANNELD_IFACE={{.ipv4_address}}
             FLANNELD_ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
 
+{{ if not (index . "skip_networkd") }}
 networkd:
   units:
     - name: 10-static.network
@@ -173,6 +174,7 @@ networkd:
         Gateway={{.networkd_gateway}}
         DNS={{.networkd_dns}}
         Address={{.networkd_address}}
+{{end}}
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:


### PR DESCRIPTION
* Example clusters can use a pre-configured DHCP server for network setup rather than provisioning hosts with a networkd config

fyi @brianredbeard 