### PR TITLE
examples: Use coreos-install baseurl

### DIFF
--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -26,7 +26,7 @@ The examples statically assign IP addresses for client VMs on the `metal0` CNI b
 
 ### Assets
 
-Download the CoreOS PXE image referenced in the target [profile](../examples/profiles).
+Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
     ./scripts/get-coreos alpha 1053.2.0
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -22,7 +22,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
     git clone https://github.com/coreos/coreos-baremetal.git
     cd coreos-baremetal
 
-Download CoreOS PXE image assets referenced by the `etcd-docker` [example](../examples) to `examples/assets`.
+Download CoreOS image assets referenced by the `etcd-docker` [example](../examples) to `examples/assets`.
 
     ./scripts/get-coreos
     ./scripts/get-coreos channel version   # examples pin a required version

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -22,7 +22,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
     git clone https://github.com/coreos/coreos-baremetal.git
     cd coreos-baremetal
 
-Download CoreOS PXE image assets referenced by the `etcd` [example](../examples) to `examples/assets`.
+Download CoreOS image assets referenced by the `etcd` [example](../examples) to `examples/assets`.
 
     ./scripts/get-coreos
     ./scripts/get-coreos channel version

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -21,7 +21,7 @@ The examples statically assign IP addresses for client VMs on the `metal0` CNI b
 
 ### Assets
 
-Download the CoreOS PXE image assets referenced in the target [profile](../examples/profiles).
+Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
     ./scripts/get-coreos alpha 1053.2.0
 

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -5,6 +5,7 @@
   "metadata": {
     "coreos_channel": "alpha",
     "coreos_version": "1053.2.0",
-    "ignition_endpoint": "http://bootcfg.foo:8080/ignition"
+    "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
+    "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }
 }

--- a/examples/groups/etcd-install/install.json
+++ b/examples/groups/etcd-install/install.json
@@ -5,6 +5,7 @@
   "metadata": {
     "coreos_channel": "alpha",
     "coreos_version": "1053.2.0",
-    "ignition_endpoint": "http://bootcfg.foo:8080/ignition"
+    "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
+    "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }
 }

--- a/examples/groups/k8s-install/install.json
+++ b/examples/groups/k8s-install/install.json
@@ -5,6 +5,7 @@
   "metadata": {
     "coreos_channel": "alpha",
     "coreos_version": "1053.2.0",
-    "ignition_endpoint": "http://bootcfg.foo:8080/ignition"
+    "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
+    "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }
 }

--- a/examples/ignition/install-reboot.yaml
+++ b/examples/ignition/install-reboot.yaml
@@ -11,7 +11,7 @@ systemd:
         [Service]
         Type=oneshot
         ExecStart=/usr/bin/curl {{.ignition_endpoint}}?{{.query}}&os=installed -o ignition.json
-        ExecStart=/usr/bin/coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json
+        ExecStart=/usr/bin/coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}}
         ExecStart=/usr/bin/udevadm settle
         ExecStart=/usr/bin/systemctl reboot
         [Install]

--- a/examples/ignition/install-shutdown.yaml
+++ b/examples/ignition/install-shutdown.yaml
@@ -11,7 +11,7 @@ systemd:
         [Service]
         Type=oneshot
         ExecStart=/usr/bin/curl {{.ignition_endpoint}}?{{.query}}&os=installed -o ignition.json
-        ExecStart=/usr/bin/coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json
+        ExecStart=/usr/bin/coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}}
         ExecStart=/usr/bin/udevadm settle
         ExecStart=/usr/bin/systemctl poweroff
         [Install]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,21 +3,23 @@
 
 ## get-coreos
 
-Run the `get-coreos` script to download CoreOS kernel and initrd images, verify them, and move them into `examples/assets`.
+Run the `get-coreos` script to download CoreOS images, verify them, and move them into `examples/assets`.
 
     ./scripts/get-coreos
     ./scripts/get-coreos channel version
 
 This will create:
 
-    assets/
+    examples/assets/
     └── coreos
-        └── 899.6.0
+        └── 1053.2.0
+            ├── CoreOS_Image_Signing_Key.asc
+            ├── coreos_production_image.bin.bz2
+            ├── coreos_production_image.bin.bz2.sig
+            ├── coreos_production_pxe_image.cpio.gz
+            ├── coreos_production_pxe_image.cpio.gz.sig
             ├── coreos_production_pxe.vmlinuz
-            └── coreos_production_pxe_image.cpio.gz
-        └── 942.0.0
-            ├── coreos_production_pxe.vmlinuz
-            └── coreos_production_pxe_image.cpio.gz
+            └── coreos_production_pxe.vmlinuz.sig
 
 ## libvirt
 

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -15,19 +15,25 @@ if [ ! -d "$DEST" ]; then
   mkdir -p $DEST
 fi
 
-echo "Downloading CoreOS kernel and initrd image assets"
+echo "Downloading CoreOS $CHANNEL $VERSION images and signatures"
 
-# kernel and sig
+# PXE kernel and sig
 echo "coreos_production_pxe.vmlinuz..."
 curl -# $BASE_URL/coreos_production_pxe.vmlinuz -o $DEST/coreos_production_pxe.vmlinuz
 echo "coreos_production_pxe.vmlinuz.sig"
 curl -# $BASE_URL/coreos_production_pxe.vmlinuz.sig -o $DEST/coreos_production_pxe.vmlinuz.sig
 
-# initrd and sig
+# PXE initrd and sig
 echo "coreos_production_pxe_image.cpio.gz"
 curl -# $BASE_URL/coreos_production_pxe_image.cpio.gz -o $DEST/coreos_production_pxe_image.cpio.gz
 echo "coreos_production_pxe_image.cpio.gz.sig"
 curl -# $BASE_URL/coreos_production_pxe_image.cpio.gz.sig -o $DEST/coreos_production_pxe_image.cpio.gz.sig
+
+# Install image
+echo "coreos_production_image.bin.bz2"
+curl -# $BASE_URL/coreos_production_image.bin.bz2 -o $DEST/coreos_production_image.bin.bz2
+echo "coreos_production_image.bin.bz2.sig"
+curl -# $BASE_URL/coreos_production_image.bin.bz2.sig -o $DEST/coreos_production_image.bin.bz2.sig
 
 # verify signatures
 echo "CoreOS Image Signing Key"
@@ -37,3 +43,4 @@ echo "Adding trust for CoreOS signing key:"
 echo "04127D0BFABEC8871FFB2CCE50E0885593D2DCB4:6:" | gpg --import-ownertrust
 gpg --verify $DEST/coreos_production_pxe.vmlinuz.sig
 gpg --verify $DEST/coreos_production_pxe_image.cpio.gz.sig
+gpg --verify $DEST/coreos_production_image.bin.bz2.sig


### PR DESCRIPTION
* Examples which install CoreOS to disk should reference a CoreOS install image from bootcfg assets to speed up installs and improve the offline use-case
* Update scripts/get-coreos to download and verify the CoreOS install image

Improves #226 