### PR TITLE
Require gRPC TLS transport security, server verification, client authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _testmain.go
 bin/
 assets/
 *.aci
+examples/etc/bootcfg/*

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ _testmain.go
 bin/
 assets/
 *.aci
-examples/etc/bootcfg/*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,10 @@
 
 ## Latest
 
-* Allow Ignition 2.0.0 JSON and YAML template files
+* Add gRPC API TLS and TLS client-to-server authentication (#140)
+    * Enable gRPC API by providing a TLS server `-cert-file` and `-key-file`, and a `-ca-file` to authenticate client certificates
+    * Provide `bootcmd` tool a TLS client `-cert-file` and `-key-file`, and a `-ca-file` to verify the server identity.
+* Allow Ignition 2.0.0 JSON and YAML template files (#141)
 * Add/improve rkt, Docker, Kubernetes, and binary/systemd deployment docs
 * Show `bootcfg` message at the home path `/`
 * Fix http package log messages and increase request logging (#173)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,16 +2,19 @@
 
 ## Latest
 
-* Add gRPC API TLS and TLS client-to-server authentication (#140)
+* TLS Authentication:
+    * Add gRPC API TLS and TLS client-to-server authentication (#140)
     * Enable gRPC API by providing a TLS server `-cert-file` and `-key-file`, and a `-ca-file` to authenticate client certificates
     * Provide `bootcmd` tool a TLS client `-cert-file` and `-key-file`, and a `-ca-file` to verify the server identity.
-* Allow Ignition 2.0.0 JSON and YAML template files (#141)
+* Improvements to Ignition Support:
+    * Allow Ignition 2.0.0 JSON and YAML template files (#141)
+    * Stop requiring Ignition templates to use file extensions (#176)
+* Logging Improvements:
+    * Show `bootcfg` message at the home path `/`
+    * Fix http package log messages and increase request logging (#173)
+    * Log requests for bootcfg hosted assets (#214)
+    * Error when an Ignition/Cloud-config template is rendered with a machine Group which is missing a metadata value. Previously, missing values defaulted to "no value" (#210)
 * Add/improve rkt, Docker, Kubernetes, and binary/systemd deployment docs
-* Show `bootcfg` message at the home path `/`
-* Fix http package log messages and increase request logging (#173)
-* Log requests for bootcfg hosted assets (#214)
-* Error when an Ignition/Cloud-config template is rendered with a machine Group which is missing a metadata value. Previously, missing values defaulted to "no value" (#210)
-* Stop requiring Ignition templates to use file extensions (#176)
 
 #### Examples
 

--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -70,7 +70,7 @@ The gRPC API can be enabled with the `-rpc-address` flag and by providing a TLS 
 
 Run the ACI with rkt and TLS credentials from `examples/etc/bootcfg`.
 
-    sudo rkt --insecure-options=image run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=config,target=/etc/bootcfg --volume config,kind=host,source=$PWD/examples/etc/bootcfg --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd bootcfg.aci -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples,readOnly=true --mount volume=config,target=/etc/bootcfg --volume config,kind=host,source=$PWD/examples/etc/bootcfg --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 
 A `bootcmd` client can call the gRPC API running at the IP used in the rkt example.
 
@@ -78,7 +78,7 @@ A `bootcmd` client can call the gRPC API running at the IP used in the rkt examp
 
 Run the Docker image with TLS credentials from `examples/etc/bootcfg`.
 
-    sudo docker run -p 8080:8080 -p 8081 --rm -v $PWD/examples:/var/lib/bootcfg:Z -v $PWD/examples/etc/bootcfg:/etc/bootcfg:Z -v $PWD/examples/groups/etcd:/var/lib/bootcfg/groups:Z coreos/bootcfg:latest -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+    sudo docker run -p 8080:8080 -p 8081:8081 --rm -v $PWD/examples:/var/lib/bootcfg:Z -v $PWD/examples/etc/bootcfg:/etc/bootcfg:Z,ro -v $PWD/examples/groups/etcd:/var/lib/bootcfg/groups:Z quay.io/coreos/bootcfg:latest -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 
 A `bootcmd` client can call the gRPC API running at the IP used in the Docker example.
 

--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -9,17 +9,25 @@ Configuration arguments can be provided as flags or as environment variables.
 | -log-level | BOOTCFG_LOG_LEVEL | info | critical, error, warning, notice, info, debug |
 | -data-path | BOOTCFG_DATA_PATH | /var/lib/bootcfg | ./examples |
 | -assets-path | BOOTCFG_ASSETS_PATH | /var/lib/bootcfg/assets | ./examples/assets |
-| -rpc-address | BOOTCFG_RPC_ADDRESS | (RPC server disabled) | 127.0.0.1:8081 |
+| -rpc-address | BOOTCFG_RPC_ADDRESS | (gRPC API disabled) | 127.0.0.1:8081 |
+| -cert-file | BOOTCFG_CERT_FILE | /etc/bootcfg/server.crt | ./examples/etc/bootcfg/server.crt |
+| -key-file | BOOTCFG_KEY_FILE | /etc/bootcfg/server.key | ./examples/etc/bootcfg/server.key
 | -key-ring-path | BOOTCFG_KEY_RING_PATH | (no key ring) | ~/.secrets/vault/bootcfg/secring.gpg |
 | (no flag) | BOOTCFG_PASSPHRASE | (no passphrase) | "secret passphrase" |
 
 ## Files and Directories
 
-| Contents | Default Location                                  |
+| Data | Default Location                                  |
 |:---------|:--------------------------------------------------|
 | data     | /var/lib/bootcfg/{profiles,groups,ignition,cloud} |
 | assets   | /var/lib/bootcfg/assets                           |
-| environment variables         |/etc/bootcfg.env                                                   |
+| environment variables | /etc/bootcfg.env                     |
+
+| gRPC API TLS Credentials | Default Location                  |
+|:---------|:--------------------------------------------------|
+| CA certificate | /etc/bootcfg/ca.crt                         |
+| Server certificate | /etc/bootcfg/server.crt                 |
+| Server Private Key | /etc/bootcfg/server.key                 |
 
 ## Version
 
@@ -45,13 +53,33 @@ Run the binary.
 
     ./bin/bootcfg -address=0.0.0.0:8080 -log-level=debug -data-path=examples -assets-path=examples/assets
 
-Run the latest ACI with rkt. Mounts are used to add the provided examples.
+Run the ACI with rkt. Mounts are used to add the provided examples.
 
     sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
 
-Run the latest Docker image. Mounts are used to add the provided examples.
+Run the Docker image. Mounts are used to add the provided examples.
 
     sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/bootcfg:Z -v $PWD/examples/groups/etcd:/var/lib/bootcfg/groups:Z quay.io/coreos/bootcfg:latest -address=0.0.0.0:8080 -log-level=debug
+
+### gRPC API
+
+The gRPC API can be enabled with the `-rpc-address` flag and by providing a TLS server certificate and key with `-cert-file` and `-key-file`. gRPC clients (such as `bootcmd`) must verify the server's certificate with a CA bundle.
+
+Run the ACI with rkt and TLS credentials from `examples/etc/bootcfg`.
+
+    sudo rkt --insecure-options=image run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=config,target=/etc/bootcfg --volume config,kind=host,source=$PWD/examples/etc/bootcfg --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd bootcfg.aci -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+
+A `bootcmd` client can call the gRPC API running at the IP used in the rkt example.
+
+    ./bin/bootcmd profile list --endpoints 172.15.0.2:8081 --ca-file examples/etc/bootcfg/ca.crt
+
+Run the Docker image with TLS credentials from `examples/etc/bootcfg`.
+
+    sudo docker run -p 8080:8080 -p 8081 --rm -v $PWD/examples:/var/lib/bootcfg:Z -v $PWD/examples/etc/bootcfg:/etc/bootcfg:Z -v $PWD/examples/groups/etcd:/var/lib/bootcfg/groups:Z coreos/bootcfg:latest -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+
+A `bootcmd` client can call the gRPC API running at the IP used in the Docker example.
+
+    ./bin/bootcmd profile list --endpoints 127.0.0.1:8081 --ca-file examples/etc/bootcfg/root.crt
 
 #### With [OpenPGP Signing](openpgp.md)
 

--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -12,6 +12,7 @@ Configuration arguments can be provided as flags or as environment variables.
 | -rpc-address | BOOTCFG_RPC_ADDRESS | (gRPC API disabled) | 127.0.0.1:8081 |
 | -cert-file | BOOTCFG_CERT_FILE | /etc/bootcfg/server.crt | ./examples/etc/bootcfg/server.crt |
 | -key-file | BOOTCFG_KEY_FILE | /etc/bootcfg/server.key | ./examples/etc/bootcfg/server.key
+| -ca-file | BOOTCFG_CA_FILE | /etc/bootcfg/ca.crt | ./examples/etc/bootcfg/ca.crt |
 | -key-ring-path | BOOTCFG_KEY_RING_PATH | (no key ring) | ~/.secrets/vault/bootcfg/secring.gpg |
 | (no flag) | BOOTCFG_PASSPHRASE | (no passphrase) | "secret passphrase" |
 
@@ -27,7 +28,9 @@ Configuration arguments can be provided as flags or as environment variables.
 |:---------|:--------------------------------------------------|
 | CA certificate | /etc/bootcfg/ca.crt                         |
 | Server certificate | /etc/bootcfg/server.crt                 |
-| Server Private Key | /etc/bootcfg/server.key                 |
+| Server private key | /etc/bootcfg/server.key                 |
+| Client certificate | /etc/bootcfg/client.crt                 |
+| Client private key | /etc/bootcfg/client.key                 |
 
 ## Version
 
@@ -63,7 +66,7 @@ Run the Docker image. Mounts are used to add the provided examples.
 
 ### gRPC API
 
-The gRPC API can be enabled with the `-rpc-address` flag and by providing a TLS server certificate and key with `-cert-file` and `-key-file`. gRPC clients (such as `bootcmd`) must verify the server's certificate with a CA bundle.
+The gRPC API can be enabled with the `-rpc-address` flag and by providing a TLS server certificate and key with `-cert-file` and `-key-file` and a CA certificate for authenticating clients with `-ca-file`. gRPC clients (such as `bootcmd`) must verify the server's certificate with a CA bundle passed via `-ca-file` and present a client certificate and key via `-cert-file` and `-key-file`.
 
 Run the ACI with rkt and TLS credentials from `examples/etc/bootcfg`.
 
@@ -71,7 +74,7 @@ Run the ACI with rkt and TLS credentials from `examples/etc/bootcfg`.
 
 A `bootcmd` client can call the gRPC API running at the IP used in the rkt example.
 
-    ./bin/bootcmd profile list --endpoints 172.15.0.2:8081 --ca-file examples/etc/bootcfg/ca.crt
+    ./bin/bootcmd profile list --endpoints 172.15.0.2:8081 --ca-file examples/etc/bootcfg/ca.crt --cert-file examples/etc/bootcfg/client.crt --key-file examples/etc/bootcfg/client.key
 
 Run the Docker image with TLS credentials from `examples/etc/bootcfg`.
 
@@ -79,7 +82,7 @@ Run the Docker image with TLS credentials from `examples/etc/bootcfg`.
 
 A `bootcmd` client can call the gRPC API running at the IP used in the Docker example.
 
-    ./bin/bootcmd profile list --endpoints 127.0.0.1:8081 --ca-file examples/etc/bootcfg/root.crt
+    ./bin/bootcmd profile list --endpoints 127.0.0.1:8081 --ca-file examples/etc/bootcfg/ca.crt --cert-file examples/etc/bootcfg/client.crt --key-file examples/etc/bootcfg/client.key
 
 #### With [OpenPGP Signing](openpgp.md)
 

--- a/Documentation/dev/develop.md
+++ b/Documentation/dev/develop.md
@@ -37,11 +37,17 @@ Run the binary.
 
 Run the ACI with rkt on `metal0`.
 
-    sudo rkt --insecure-options=image run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd bootcfg.aci -- -address=0.0.0.0:8080 -log-level=debug
+    sudo rkt --insecure-options=image run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=config,target=/etc/bootcfg --volume config,kind=host,source=$PWD/examples/etc/bootcfg --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd bootcfg.aci -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 
 Alternately, run the Docker image on `docker0`.
 
     sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/bootcfg:Z -v $PWD/examples/groups/etcd-docker:/var/lib/bootcfg/groups:Z coreos/bootcfg:latest -address=0.0.0.0:8080 -log-level=debug
+
+### bootcmd
+
+Run `bootcmd` against the gRPC API of the service running via rkt.
+
+    ./bin/bootcmd profile list --endpoints 172.15.0.2:8081 --cacert examples/etc/bootcfg/ca.crt
 
 ## Dependencies
 

--- a/bootcfg/cli/root.go
+++ b/bootcfg/cli/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/coreos/coreos-baremetal/bootcfg/client"
+	"github.com/coreos/coreos-baremetal/bootcfg/tlsutil"
 )
 
 var (
@@ -22,11 +23,14 @@ To get help about a resource or command, run "bootcmd help resource"`,
 	// globalFlags can be set for any subcommand.
 	globalFlags = struct {
 		Endpoints []string
+		CAFile    string
 	}{}
 )
 
 func init() {
 	RootCmd.PersistentFlags().StringSliceVar(&globalFlags.Endpoints, "endpoints", []string{"127.0.0.1:8081"}, "gRPC Endpoints")
+	// gRPC Client TLS
+	RootCmd.PersistentFlags().StringVar(&globalFlags.CAFile, "ca-file", "/etc/bootcfg/ca.crt", "Path to the CA bundle to verify certificates of TLS servers")
 	cobra.EnablePrefixMatching = true
 }
 
@@ -41,16 +45,41 @@ func Execute() {
 
 // mustClientFromCmd returns a gRPC client or exits.
 func mustClientFromCmd(cmd *cobra.Command) *client.Client {
-	endpoints, err := cmd.Flags().GetStringSlice("endpoints")
+	endpoints := endpointsFromCmd(cmd)
+	tlsinfo := tlsInfoFromCmd(cmd)
+
+	// client config
+	tlscfg, err := tlsinfo.ClientConfig()
 	if err != nil {
-		exitWithError(ExitError, err)
+		exitWithError(ExitBadArgs, err)
 	}
 	cfg := &client.Config{
 		Endpoints: endpoints,
+		TLS:       tlscfg,
 	}
+
+	// gRPC client
 	client, err := client.New(cfg)
 	if err != nil {
 		exitWithError(ExitBadConnection, err)
 	}
 	return client
+}
+
+// endpointsFromCmd returns the endpoint arguments.
+func endpointsFromCmd(cmd *cobra.Command) []string {
+	endpoints, err := cmd.Flags().GetStringSlice("endpoints")
+	if err != nil {
+		exitWithError(ExitBadArgs, err)
+	}
+	return endpoints
+}
+
+// tlsInfoFromCmd collects TLS arguments and returns a TLSInfo struct.
+func tlsInfoFromCmd(cmd *cobra.Command) *tlsutil.TLSInfo {
+	caFile, err := cmd.Flags().GetString("ca-file")
+	if err != nil {
+		exitWithError(ExitBadArgs, err)
+	}
+	return &tlsutil.TLSInfo{CAFile: caFile}
 }

--- a/bootcfg/cli/root.go
+++ b/bootcfg/cli/root.go
@@ -22,15 +22,20 @@ To get help about a resource or command, run "bootcmd help resource"`,
 
 	// globalFlags can be set for any subcommand.
 	globalFlags = struct {
-		Endpoints []string
-		CAFile    string
+		endpoints []string
+		caFile    string
+		certFile  string
+		keyFile   string
 	}{}
 )
 
 func init() {
-	RootCmd.PersistentFlags().StringSliceVar(&globalFlags.Endpoints, "endpoints", []string{"127.0.0.1:8081"}, "gRPC Endpoints")
-	// gRPC Client TLS
-	RootCmd.PersistentFlags().StringVar(&globalFlags.CAFile, "ca-file", "/etc/bootcfg/ca.crt", "Path to the CA bundle to verify certificates of TLS servers")
+	RootCmd.PersistentFlags().StringSliceVar(&globalFlags.endpoints, "endpoints", []string{"127.0.0.1:8081"}, "gRPC Endpoints")
+	// gRPC TLS Server Verification
+	RootCmd.PersistentFlags().StringVar(&globalFlags.caFile, "ca-file", "/etc/bootcfg/ca.crt", "Path to the CA bundle to verify certificates of TLS servers")
+	// gRPC TLS Client Authentication
+	RootCmd.PersistentFlags().StringVar(&globalFlags.certFile, "cert-file", "/etc/bootcfg/client.crt", "Path to the client TLS certificate file")
+	RootCmd.PersistentFlags().StringVar(&globalFlags.keyFile, "key-file", "/etc/bootcfg/client.key", "Path to the client TLS key file")
 	cobra.EnablePrefixMatching = true
 }
 
@@ -81,5 +86,18 @@ func tlsInfoFromCmd(cmd *cobra.Command) *tlsutil.TLSInfo {
 	if err != nil {
 		exitWithError(ExitBadArgs, err)
 	}
-	return &tlsutil.TLSInfo{CAFile: caFile}
+	certFile, err := cmd.Flags().GetString("cert-file")
+	if err != nil {
+		exitWithError(ExitBadArgs, err)
+	}
+	keyFile, err := cmd.Flags().GetString("key-file")
+	if err != nil {
+		exitWithError(ExitBadArgs, err)
+	}
+
+	return &tlsutil.TLSInfo{
+		CAFile:   caFile,
+		CertFile: certFile,
+		KeyFile:  keyFile,
+	}
 }

--- a/bootcfg/rpc/grpc.go
+++ b/bootcfg/rpc/grpc.go
@@ -1,18 +1,27 @@
 package rpc
 
 import (
+	"crypto/tls"
+
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/coreos/coreos-baremetal/bootcfg/rpc/rpcpb"
 	"github.com/coreos/coreos-baremetal/bootcfg/server"
 )
 
 // NewServer wraps the bootcfg Server to return a new gRPC Server.
-func NewServer(s server.Server, opts ...grpc.ServerOption) (*grpc.Server, error) {
+func NewServer(s server.Server, tls *tls.Config) *grpc.Server {
+	var opts []grpc.ServerOption
+	if tls != nil {
+		// Add TLS Credentials as a ServerOption for server connections.
+		opts = append(opts, grpc.Creds(credentials.NewTLS(tls)))
+	}
+
 	grpcServer := grpc.NewServer(opts...)
 	rpcpb.RegisterGroupsServer(grpcServer, newGroupServer(s))
 	rpcpb.RegisterProfilesServer(grpcServer, newProfileServer(s))
 	rpcpb.RegisterSelectServer(grpcServer, newSelectServer(s))
 	rpcpb.RegisterIgnitionServer(grpcServer, newIgnitionServer(s))
-	return grpcServer, nil
+	return grpcServer
 }

--- a/bootcfg/tlsutil/info.go
+++ b/bootcfg/tlsutil/info.go
@@ -1,0 +1,41 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+)
+
+// TLSInfo prepares tls.Config's from TLS file inputs.
+type TLSInfo struct {
+	CAFile   string
+	CertFile string
+	KeyFile  string
+}
+
+// ClientConfig returns a tls.Config for client use.
+func (info *TLSInfo) ClientConfig() (*tls.Config, error) {
+	pool, err := NewCertPool([]string{info.CAFile})
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: false,
+		// CA bundle the client should trust when verifying a server
+		RootCAs: pool,
+	}, nil
+}
+
+// ServerConfig returns a tls.Config for server use.
+func (info *TLSInfo) ServerConfig() (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(info.CertFile, info.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		// Certificates the server should present to clients
+		Certificates: []tls.Certificate{cert},
+	}, nil
+}

--- a/bootcfg/tlsutil/info.go
+++ b/bootcfg/tlsutil/info.go
@@ -57,5 +57,11 @@ func (info *TLSInfo) ServerConfig() (*tls.Config, error) {
 		ClientAuth: tls.RequireAndVerifyClientCert,
 		// CA for verifying and authorizing client certificates
 		ClientCAs: pool,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		},
 	}, nil
 }

--- a/bootcfg/tlsutil/tlsutil.go
+++ b/bootcfg/tlsutil/tlsutil.go
@@ -1,0 +1,34 @@
+package tlsutil
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+)
+
+// NewCertPool creates x509 certPool with provided CA files.
+func NewCertPool(CAFiles []string) (*x509.CertPool, error) {
+	certPool := x509.NewCertPool()
+
+	for _, CAFile := range CAFiles {
+		pemByte, err := ioutil.ReadFile(CAFile)
+		if err != nil {
+			return nil, err
+		}
+
+		for {
+			var block *pem.Block
+			block, pemByte = pem.Decode(pemByte)
+			if block == nil {
+				break
+			}
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			certPool.AddCert(cert)
+		}
+	}
+
+	return certPool, nil
+}

--- a/cmd/bootcfg/main.go
+++ b/cmd/bootcfg/main.go
@@ -34,6 +34,7 @@ func main() {
 		logLevel    string
 		certFile    string
 		keyFile     string
+		caFile      string
 		keyRingPath string
 		version     bool
 		help        bool
@@ -49,6 +50,8 @@ func main() {
 	// gRPC Server TLS
 	flag.StringVar(&flags.certFile, "cert-file", "/etc/bootcfg/server.crt", "Path to the server TLS certificate file")
 	flag.StringVar(&flags.keyFile, "key-file", "/etc/bootcfg/server.key", "Path to the server TLS key file")
+	// TLS Client Authentication
+	flag.StringVar(&flags.caFile, "ca-file", "/etc/bootcfg/ca.crt", "Path to the CA verify and authenticate client certificates")
 
 	// Signing
 	flag.StringVar(&flags.keyRingPath, "key-ring-path", "", "Path to a private keyring file")
@@ -133,6 +136,7 @@ func main() {
 		tlsinfo := tlsutil.TLSInfo{
 			CertFile: flags.certFile,
 			KeyFile:  flags.keyFile,
+			CAFile:   flags.caFile,
 		}
 		tlscfg, err := tlsinfo.ServerConfig()
 		if err != nil {

--- a/cmd/bootcfg/main.go
+++ b/cmd/bootcfg/main.go
@@ -87,13 +87,18 @@ func main() {
 	}
 	if flags.assetsPath != "" {
 		if finfo, err := os.Stat(flags.assetsPath); err != nil || !finfo.IsDir() {
-			log.Printf("Provide a valid -assets-path or '' to disable asset serving: %s", flags.assetsPath)
+			log.Fatalf("Provide a valid -assets-path or '' to disable asset serving: %s", flags.assetsPath)
 		}
 	}
-
 	if flags.rpcAddress != "" {
-		if flags.certFile == "" || flags.keyFile == "" {
-			log.Fatalf("Provide a server -cert and -key to be able to use the gRPC API")
+		if _, err := os.Stat(flags.certFile); err != nil {
+			log.Fatalf("Provide a valid TLS server certificate with -cert-file: %v", err)
+		}
+		if _, err := os.Stat(flags.keyFile); err != nil {
+			log.Fatalf("Provide a valid TLS server key with -key-file: %v", err)
+		}
+		if _, err := os.Stat(flags.caFile); err != nil {
+			log.Fatalf("Provide a valid TLS certificate authority for authorizing client certificates: %v", err)
 		}
 	}
 
@@ -129,6 +134,9 @@ func main() {
 	// gRPC Server (feature disabled by default)
 	if flags.rpcAddress != "" {
 		log.Infof("starting bootcfg gRPC server on %s", flags.rpcAddress)
+		log.Infof("Using TLS server certificate: %s", flags.certFile)
+		log.Infof("Using TLS server key: %s", flags.keyFile)
+		log.Infof("Using CA certificate: %s to authenticate client certificates", flags.caFile)
 		lis, err := net.Listen("tcp", flags.rpcAddress)
 		if err != nil {
 			log.Fatalf("failed to start listening: %v", err)

--- a/examples/etc/bootcfg/.gitignore
+++ b/examples/etc/bootcfg/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!README.md
+!cert-gen
+!openssl.conf

--- a/examples/etc/bootcfg/README.md
+++ b/examples/etc/bootcfg/README.md
@@ -1,0 +1,36 @@
+
+## gRPC API Credentials
+
+Create FAKE TLS credentials for running the `bootcfg` gRPC API examples.
+
+**DO NOT** use these certificates for anything other than running `bootcfg` examples. Use your organization's production PKI for production deployments.
+
+Navigate to the example directory which will be mounted as `/etc/bootcfg` in examples:
+
+    cd coreos-baremetal/examples/etc/bootcfg
+
+Create a fake `ca.crt`, `server.crt`, `server.key`, `client.crt`, and `client.key`. Type 'Y' when prompted.
+
+    $ ./cert-gen
+    Creating FAKE CA, server cert/key, and client cert/key...
+    ...
+    ...
+    ...
+    ******************************************************************
+    WARNING: Generated TLS credentials are ONLY SUITABLE FOR EXAMPLES!
+    Use your organization's production PKI for production deployments!
+
+## Inpsect
+
+Inspect the generated FAKE certificates if desired.
+
+    openssl x509 -noout -text -in ca.crt
+    openssl x509 -noout -text -in server.crt
+    openssl x509 -noout -text -in client.crt
+
+## Verify
+
+Verify that the FAKE server and client certificates were signed by the fake CA.
+
+    openssl verify -CAfile ca.crt server.crt
+    openssl verify -CAfile ca.crt client.crt

--- a/examples/etc/bootcfg/cert-gen
+++ b/examples/etc/bootcfg/cert-gen
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+# note: Script uses -subj, rather than setting distinguished names interactively
+
+rm -f ca.key ca.crt server.key server.csr server.crt client.key client.csr client.crt index.* serial*
+rm -rf certs crl newcerts
+
+echo "Creating FAKE CA, server cert/key, and client cert/key..."
+
+# basic files/directories
+mkdir -p {certs,crl,newcerts}
+touch index.txt
+echo 1000 > serial
+
+# CA private key (unencrypted)
+openssl genrsa -out ca.key 4096
+# Certificate Authority (self-signed certificate)
+openssl req -config openssl.conf -new -x509 -days 3650 -sha256 -key ca.key -extensions v3_ca -out ca.crt -subj "/CN=fake-ca"
+
+# End-entity certificates
+
+# Server private key (unencrypted)
+openssl genrsa -out server.key 2048
+# Server certificate signing request (CSR)
+openssl req -config openssl.conf -new -sha256 -key server.key -out server.csr -subj "/CN=fake-server"
+# Suitable SANs for bootcfg on 172.15.0.2(rkt example) and 127.0.0.1(docker example)
+export SAN=IP.1:127.0.0.1,IP.2:172.15.0.2
+# Certificate Authority signs CSR to grant a certificate
+openssl ca -config openssl.conf -extensions server_cert -days 365 -notext -md sha256 -in server.csr -out server.crt -cert ca.crt -keyfile ca.key
+
+# Client private key (unencrypted)
+openssl genrsa -out client.key 2048
+# Signed client certificate signing request (CSR)
+openssl req -config openssl.conf -new -sha256 -key client.key -out client.csr -subj "/CN=fake-client"
+# Certificate Authority signs CSR to grant a certificate
+openssl ca -config openssl.conf -extensions usr_cert -days 365 -notext -md sha256 -in client.csr -out client.crt -cert ca.crt -keyfile ca.key
+
+echo "******************************************************************"
+echo "WARNING: Generated TLS credentials are ONLY SUITABLE FOR EXAMPLES!"
+echo "Use your organization's production PKI for production deployments!"

--- a/examples/etc/bootcfg/openssl.conf
+++ b/examples/etc/bootcfg/openssl.conf
@@ -1,0 +1,82 @@
+# OpenSSL configuration file.
+# Adapted from github.com/dghubble/pegasus
+
+# default environment variable values
+SAN =
+
+[ ca ]
+# `man ca`
+default_ca = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir               = .
+certs             = $dir/certs
+crl_dir           = $dir/crl
+new_certs_dir     = $dir/newcerts
+database          = $dir/index.txt
+serial            = $dir/serial
+# certificate revocation lists.
+crlnumber         = $dir/crlnumber
+crl               = $dir/crl/intermediate-ca.crl
+crl_extensions    = crl_ext
+default_crl_days  = 30
+default_md        = sha256
+
+name_opt          = ca_default
+cert_opt          = ca_default
+default_days      = 375
+preserve          = no
+policy            = policy_loose
+
+[ policy_loose ]
+# Allow the CA to sign a range of certificates.
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = supplied
+emailAddress            = optional
+
+[ req ]
+# `man req`
+default_bits        = 4096
+distinguished_name  = req_distinguished_name
+string_mask         = utf8only
+default_md          = sha256
+
+[ req_distinguished_name ]
+countryName                    = Country Name (2 letter code)
+stateOrProvinceName            = State or Province Name
+localityName                   = Locality Name
+0.organizationName             = Organization Name
+organizationalUnitName         = Organizational Unit Name
+commonName                     = Common Name
+
+# Certificate extensions (`man x509v3_config`)
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true, pathlen:0
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+
+[ usr_cert ]
+basicConstraints = CA:FALSE
+nsCertType = client
+nsComment = "OpenSSL Generated Client Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+
+[ server_cert ]
+basicConstraints = CA:FALSE
+nsCertType = server
+nsComment = "OpenSSL Generated Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = $ENV::SAN


### PR DESCRIPTION
* Add gRPC client-to-server TLS transport security and server verification (prevent MITM)
    * A CA certificate (e.g. ca.crt) should be used to sign a server certificate (server.crt for a private key server.key)
    * gRPC API server requires a server certificate and key to be enabled (passed via -cert-file and -key-file)
    * gRPC client bootcmd tool must verify the server identity using a known CA (passed to bootcmd via -ca-file)
* Example client and server commands/flags with rkt and Docker
* Require TLS client auth for gRPC API
    * gRPC API server requires a CA certificate to authenticate clients (passed via -ca-file)
    * gRPC clients must authenticate with a client certificate and key (passed via -cert-file and -key-file)
* Add examples/etc/bootcfg/cert-gen to create fake (ca, server, client) credentials for running the gRPC API examples locally. 

rel #140 cc @gtank @brianredbeard 