### PR TITLE
Log error when profile not found

### DIFF
--- a/bootcfg/http/ipxe.go
+++ b/bootcfg/http/ipxe.go
@@ -34,6 +34,7 @@ func ipxeHandler() ContextHandler {
 	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 		profile, err := profileFromContext(ctx)
 		if err != nil {
+			log.Errorf("Error finding profile: %v", err)
 			http.NotFound(w, req)
 			return
 		}


### PR DESCRIPTION
I found this useful when debugging iPXE booting.

@dghubble if you like this direction I can add more logging to the other handlers. If you want this to be debug level logging vs. error I can do that too.