### PR TITLE
examples/bootkube: Use bootkube image and disable auto-updates

### DIFF
--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -55,24 +55,23 @@ Create a network boot environment with `coreos/dnsmasq` and create VMs with `scr
 
 We're ready to use [bootkube](https://github.com/coreos/bootkube) to create a temporary control plane and bootstrap self-hosted Kubernetes cluster. This is a **one-time** procedure.
 
-Secure copy the `bootkube` generated assets to any one of the master nodes.
-
-    scp -r assets core@172.15.0.21:/home/core/assets
-    scp $(which bootkube) core@172.15.0.21:/home/core
-
 Secure copy the `kubeconfig` to `/etc/kuberentes/kubeconfig` on **every** node (repeat for 172.15.0.22, 172.15.0.23).
 
     scp assets/auth/kubeconfig core@172.15.0.21:/home/core/kubeconfig
     ssh core@172.15.0.21
     sudo mv kubeconfig /etc/kubernetes/kubeconfig
 
-Connect to the Kubernetes master node,
+Secure copy the `bootkube` generated assets to any one of the master nodes.
+
+    scp -r assets core@172.15.0.21:/home/core/assets
+
+Connect to the chosen Kubernetes master node,
 
     ssh core@172.15.0.21
 
 and run the following commands *on the node*.
 
-    sudo ./bootkube start --asset-dir=/home/core/assets --etcd-server=http://172.15.0.21:2379
+    sudo ./bootkube-start
 
 Watch the temporary control plane logs until the scheduled kubelet takes over in place of the runonce host kubelet.
 

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -5,7 +5,7 @@ The self-hosted Kubernetes examples provision a 3 node cluster with etcd, flanne
 
 ## Experimental
 
-Self-hosted Kubernetes is under very active development by CoreOS. We're working on upstreaming the required Hyperkube patches. Be aware that a deployment with a single apiserver cannot tolerate its failure. We'll be improving this to allow CoreOS auto-updates.
+Self-hosted Kubernetes is under very active development by CoreOS. We're working on upstreaming the required Hyperkube patches. Be aware that this cluster disabled auto-updates until checkpointing is available to restart a the kube-apiserver.
 
 ## Requirements
 
@@ -69,7 +69,7 @@ Connect to the chosen Kubernetes master node,
 
     ssh core@172.15.0.21
 
-and run the following commands *on the node*.
+and run the following command *on the node*.
 
     sudo ./bootkube-start
 

--- a/examples/ignition/bootkube-master.yaml
+++ b/examples/ignition/bootkube-master.yaml
@@ -57,7 +57,7 @@ systemd:
           --allow-privileged \
           --hostname-override={{.ipv4_address}} \
           --node-labels=master=true \
-          --minimum-container-ttl-duration=3m0s \
+          --minimum-container-ttl-duration=6m0s \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         Restart=always
@@ -88,6 +88,23 @@ storage:
         - path: /etc/kubernetes/empty
           mode: 0644
           contents: |
+        - path: /home/core/bootkube-start
+          mode: 0544
+          uid: 500
+          gid: 500
+          contents: |
+            #!/bin/bash
+            # Wrapper for bootkube start
+            set -e
+            BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
+            BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.1.0}"
+            BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/home/core/assets}"
+            exec /usr/bin/rkt run \
+              --trust-keys-from-https \
+              --volume assets,kind=host,source=$BOOTKUBE_ASSETS \
+              --mount volume=assets,target=/assets \
+              $RKT_OPTS \
+              ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} --net=host --exec=/bootkube -- start --asset-dir=/assets --etcd-server=http://127.0.0.1:2379 "$@"
         - path: /opt/init-flannel
           mode: 0544
           contents: |

--- a/examples/ignition/bootkube-master.yaml
+++ b/examples/ignition/bootkube-master.yaml
@@ -64,6 +64,12 @@ systemd:
         RestartSec=10
         [Install]
         WantedBy=multi-user.target
+    - name: update-engine.service
+      enable: false
+      mask: true
+    - name: locksmithd.service
+      enable: false
+      mask : true
 
 storage:
   {{ if index . "pxe" }}

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -58,6 +58,12 @@ systemd:
         RestartSec=5
         [Install]
         WantedBy=multi-user.target
+    - name: update-engine.service
+      enable: false
+      mask: true
+    - name: locksmithd.service
+      enable: false
+      mask : true
 
 storage:
   {{ if index . "pxe" }}

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -51,7 +51,7 @@ systemd:
           --exit-on-lock-contention \
           --allow-privileged \
           --hostname-override={{.ipv4_address}} \
-          --minimum-container-ttl-duration=3m0s \
+          --minimum-container-ttl-duration=6m0s \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         Restart=always


### PR DESCRIPTION
* Users no longer need to scp a bootkube binary
* Disable auto-updates until kube-apiserver checkpointing is done

@aaronlevy 