### PR TITLE
examples/bootkube: Upgrade from bootkube v0.1 to v0.1.1

### DIFF
--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -5,7 +5,7 @@ The self-hosted Kubernetes examples provision a 3 node cluster with etcd, flanne
 
 ## Experimental
 
-Self-hosted Kubernetes is under very active development by CoreOS. We're working on upstreaming the required Hyperkube patches. Be aware that this cluster disabled auto-updates until checkpointing is available to restart a the kube-apiserver.
+Self-hosted Kubernetes is under very active development by CoreOS.
 
 ## Requirements
 
@@ -15,7 +15,7 @@ Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) g
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
 
-Build and install [bootkube](https://github.com/coreos/bootkube).
+Build and install [bootkube](https://github.com/coreos/bootkube/releases) v0.1.1.
 
 ## Examples
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,8 +22,8 @@ Get started running `bootcfg` on your Linux machine to network boot and provisio
 
 * [bootcfg with rkt](../Documentation/getting-started-rkt.md)
 * [bootcfg with Docker](../Documentation/getting-started-docker.md)
-* [Kubernetes v1.2.4](../Documentation/kubernetes.md)
-* [Self-hosted Kubernetes](../Documentation/bootkube.md)
+* [Static Kubernetes](../Documentation/kubernetes.md) v1.2.4
+* [Self-hosted Kubernetes](../Documentation/bootkube.md) v1.3.0-beta.2
 * [Torus Storage](..Documentation/torus.md)
 
 ## Experimental

--- a/examples/ignition/bootkube-master.yaml
+++ b/examples/ignition/bootkube-master.yaml
@@ -48,12 +48,16 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.3.0-alpha.5_coreos.0
+        Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers={{.k8s_master_endpoint}} \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention \
+          --config=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override={{.ipv4_address}} \
           --node-labels=master=true \
@@ -64,12 +68,6 @@ systemd:
         RestartSec=10
         [Install]
         WantedBy=multi-user.target
-    - name: update-engine.service
-      enable: false
-      mask: true
-    - name: locksmithd.service
-      enable: false
-      mask : true
 
 storage:
   {{ if index . "pxe" }}
@@ -103,7 +101,7 @@ storage:
             # Wrapper for bootkube start
             set -e
             BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-            BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.1.0}"
+            BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.1.1}"
             BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/home/core/assets}"
             exec /usr/bin/rkt run \
               --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -43,12 +43,16 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.3.0-alpha.5_coreos.0
+        Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers={{.k8s_master_endpoint}} \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention \
+          --config=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override={{.ipv4_address}} \
           --minimum-container-ttl-duration=6m0s \
@@ -58,12 +62,6 @@ systemd:
         RestartSec=5
         [Install]
         WantedBy=multi-user.target
-    - name: update-engine.service
-      enable: false
-      mask: true
-    - name: locksmithd.service
-      enable: false
-      mask : true
 
 storage:
   {{ if index . "pxe" }}


### PR DESCRIPTION
* Upgrade the self-hosted Kubernetes cluster example to use bootkube v0.1.1 which supports apiserver checkpointing in order to tolerate apiserver downtime (e.g. controller reboot)
* Bumps Kubernetes version to v1.3.0-beta.2
* Re-enable CoreOS auto-updates

cc @derekparker 