### PR TITLE
Fix Kubernetes v1.2.4 clusters (static manifest variant)

### DIFF
--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -30,6 +30,7 @@ Download CoreOS image assets referenced by the `etcd-docker` [example](../exampl
 
 Run the latest `bootcfg` Docker image from `quay.io/coreos/bootcfg` with the `etcd-docker` example. The container should receive the IP address 172.17.0.2 on the `docker0` bridge.
 
+    sudo docker pull quay.io/coreos/bootcfg:latest
     sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/bootcfg:Z -v $PWD/examples/groups/etcd-docker:/var/lib/bootcfg/groups:Z quay.io/coreos/bootcfg:latest -address=0.0.0.0:8080 -log-level=debug
 
 Take a look at the [etcd groups](../examples/groups/etcd-docker) to get an idea of how machines are mapped to Profiles. Explore some endpoints port mapped to localhost:8080.

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -7,7 +7,7 @@ In this tutorial, we'll run `bootcfg` on your Linux machine with `rkt` and `CNI`
 
 ## Requirements
 
-Install [rkt](https://github.com/coreos/rkt/releases) and [acbuild](https://github.com/appc/acbuild/releases) from the latest releases ([example script](https://github.com/dghubble/phoenix/blob/master/scripts/fedora/sources.sh)). Optionally setup rkt [privilege separation](https://coreos.com/rkt/docs/latest/trying-out-rkt.html).
+Install [rkt](https://coreos.com/rkt/docs/latest/distributions.html) 1.8 or higher ([example script](https://github.com/dghubble/phoenix/blob/master/scripts/fedora/sources.sh)) and setup rkt [privilege separation](https://coreos.com/rkt/docs/latest/trying-out-rkt.html).
 
 Next, install the package dependencies.
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -1,7 +1,7 @@
 
 # Kubernetes
 
-The Kubernetes examples provision a 3 node v1.2.4 Kubernetes cluster with one master, two workers, and TLS authentication. A 3 node etcd cluster is run on the hosts for Kubernetes and to coordinate CoreOS auto-updates (if installed to disk).
+The Kubernetes examples provision a 3 node v1.2.4 Kubernetes cluster with one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -50,7 +50,7 @@ Revisit [bootcfg with rkt](getting-started-rkt.md) or [bootcfg with Docker](gett
     cd /path/to/coreos-baremetal
     kubectl --kubeconfig=examples/assets/tls/kubeconfig get nodes
     NAME          STATUS                     AGE
-    172.15.0.21   Ready,SchedulingDisabled   6m
+    172.15.0.21   Ready                      6m
     172.15.0.22   Ready                      5m
     172.15.0.23   Ready                      6m
 

--- a/examples/groups/k8s-docker/node1.json
+++ b/examples/groups/k8s-docker/node1.json
@@ -6,12 +6,12 @@
     "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
+    "etcd_initial_cluster": "node1=http://172.17.0.21:2380",
     "etcd_name": "node1",
     "ipv4_address": "172.17.0.21",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
+    "k8s_etcd_endpoints": "http://172.17.0.21:2379",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
     "networkd_address": "172.17.0.21/16",

--- a/examples/groups/k8s-docker/node1.json
+++ b/examples/groups/k8s-docker/node1.json
@@ -1,6 +1,6 @@
 {
   "id": "node1",
-  "name": "Master Node",
+  "name": "k8s controller",
   "profile": "k8s-master",
   "selector": {
     "mac": "52:54:00:a1:9c:ae"
@@ -8,7 +8,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
     "etcd_name": "node1",
-    "fleet_metadata": "role=etcd,name=node1",
     "ipv4_address": "172.17.0.21",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_dns_service_ip": "10.3.0.10",

--- a/examples/groups/k8s-docker/node2.json
+++ b/examples/groups/k8s-docker/node2.json
@@ -1,6 +1,6 @@
 {
   "id": "node2",
-  "name": "Worker 1",
+  "name": "k8s worker",
   "profile": "k8s-worker",
   "selector": {
     "mac": "52:54:00:b2:2f:86"
@@ -8,7 +8,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
     "etcd_name": "node2",
-    "fleet_metadata": "role=etcd,name=node2",
     "ipv4_address": "172.17.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.17.0.21",

--- a/examples/groups/k8s-docker/node2.json
+++ b/examples/groups/k8s-docker/node2.json
@@ -6,13 +6,12 @@
     "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
-    "etcd_name": "node2",
+    "etcd_initial_cluster": "node1=http://172.17.0.21:2380",
     "ipv4_address": "172.17.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.17.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
+    "k8s_etcd_endpoints": "http://172.17.0.21:2379",
     "networkd_address": "172.17.0.22/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-docker/node3.json
+++ b/examples/groups/k8s-docker/node3.json
@@ -6,13 +6,12 @@
     "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
-    "etcd_name": "node3",
+    "etcd_initial_cluster": "node1=http://172.17.0.21:2380",
     "ipv4_address": "172.17.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.17.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_etcd_endpoints": "http://172.17.0.21:2379,http://172.17.0.22:2379,http://172.17.0.23:2379",
+    "k8s_etcd_endpoints": "http://172.17.0.21:2379",
     "networkd_address": "172.17.0.23/16",
     "networkd_dns": "172.17.0.3",
     "networkd_gateway": "172.17.0.1",

--- a/examples/groups/k8s-docker/node3.json
+++ b/examples/groups/k8s-docker/node3.json
@@ -1,6 +1,6 @@
 {
   "id": "node3",
-  "name": "Worker 2",
+  "name": "k8s worker",
   "profile": "k8s-worker",
   "selector": {
     "mac": "52:54:00:c3:61:77"
@@ -8,7 +8,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.17.0.21:2380,node2=http://172.17.0.22:2380,node3=http://172.17.0.23:2380",
     "etcd_name": "node3",
-    "fleet_metadata": "role=etcd,name=node3",
     "ipv4_address": "172.17.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.17.0.21",

--- a/examples/groups/k8s-install/node1.json
+++ b/examples/groups/k8s-install/node1.json
@@ -7,12 +7,12 @@
     "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
+    "etcd_initial_cluster": "node1=http://172.15.0.21:2380",
     "etcd_name": "node1",
     "ipv4_address": "172.15.0.21",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
+    "k8s_etcd_endpoints": "http://172.15.0.21:2379",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",
     "networkd_address": "172.15.0.21/16",

--- a/examples/groups/k8s-install/node1.json
+++ b/examples/groups/k8s-install/node1.json
@@ -1,6 +1,6 @@
 {
   "id": "node1",
-  "name": "Master Node",
+  "name": "k8s controller",
   "profile": "k8s-master-install",
   "selector": {
     "os": "installed",
@@ -9,7 +9,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node1",
-    "fleet_metadata": "role=etcd,name=node1",
     "ipv4_address": "172.15.0.21",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_dns_service_ip": "10.3.0.10",

--- a/examples/groups/k8s-install/node2.json
+++ b/examples/groups/k8s-install/node2.json
@@ -7,13 +7,12 @@
     "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
-    "etcd_name": "node2",
+    "etcd_initial_cluster": "node1=http://172.15.0.21:2380",
     "ipv4_address": "172.15.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
+    "k8s_etcd_endpoints": "http://172.15.0.21:2379",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1"

--- a/examples/groups/k8s-install/node2.json
+++ b/examples/groups/k8s-install/node2.json
@@ -1,6 +1,6 @@
 {
   "id": "node2",
-  "name": "Worker 1",
+  "name": "k8s worker",
   "profile": "k8s-worker-install",
   "selector": {
     "os": "installed",
@@ -9,7 +9,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node2",
-    "fleet_metadata": "role=etcd,name=node2",
     "ipv4_address": "172.15.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",

--- a/examples/groups/k8s-install/node3.json
+++ b/examples/groups/k8s-install/node3.json
@@ -7,13 +7,12 @@
     "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
-    "etcd_name": "node3",
+    "etcd_initial_cluster": "node1=http://172.15.0.21:2380",
     "ipv4_address": "172.15.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
+    "k8s_etcd_endpoints": "http://172.15.0.21:2379",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1"

--- a/examples/groups/k8s-install/node3.json
+++ b/examples/groups/k8s-install/node3.json
@@ -1,6 +1,6 @@
 {
   "id": "node3",
-  "name": "Worker 2",
+  "name": "k8s worker",
   "profile": "k8s-worker-install",
   "selector": {
     "os": "installed",
@@ -9,7 +9,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node3",
-    "fleet_metadata": "role=etcd,name=node3",
     "ipv4_address": "172.15.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",

--- a/examples/groups/k8s/node1.json
+++ b/examples/groups/k8s/node1.json
@@ -1,6 +1,6 @@
 {
   "id": "node1",
-  "name": "Master Node",
+  "name": "k8s controller",
   "profile": "k8s-master",
   "selector": {
     "mac": "52:54:00:a1:9c:ae"
@@ -8,7 +8,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node1",
-    "fleet_metadata": "role=etcd,name=node1",
     "ipv4_address": "172.15.0.21",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_dns_service_ip": "10.3.0.10",

--- a/examples/groups/k8s/node1.json
+++ b/examples/groups/k8s/node1.json
@@ -6,7 +6,7 @@
     "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
+    "etcd_initial_cluster": "node1=http://172.15.0.21:2380",
     "etcd_name": "node1",
     "ipv4_address": "172.15.0.21",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",

--- a/examples/groups/k8s/node2.json
+++ b/examples/groups/k8s/node2.json
@@ -1,6 +1,6 @@
 {
   "id": "node2",
-  "name": "Worker 1",
+  "name": "k8s worker",
   "profile": "k8s-worker",
   "selector": {
     "mac": "52:54:00:b2:2f:86"
@@ -8,7 +8,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node2",
-    "fleet_metadata": "role=etcd,name=node2",
     "ipv4_address": "172.15.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",

--- a/examples/groups/k8s/node2.json
+++ b/examples/groups/k8s/node2.json
@@ -6,13 +6,12 @@
     "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
-    "etcd_name": "node2",
+    "etcd_initial_cluster": "node1=http://172.15.0.21:2380",
     "ipv4_address": "172.15.0.22",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
+    "k8s_etcd_endpoints": "http://172.15.0.21:2379",
     "networkd_address": "172.15.0.22/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node3.json
+++ b/examples/groups/k8s/node3.json
@@ -6,13 +6,12 @@
     "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
-    "etcd_name": "node3",
+    "etcd_initial_cluster": "node1=http://172.15.0.21:2380",
     "ipv4_address": "172.15.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",
     "k8s_dns_service_ip": "10.3.0.10",
-    "k8s_etcd_endpoints": "http://172.15.0.21:2379,http://172.15.0.22:2379,http://172.15.0.23:2379",
+    "k8s_etcd_endpoints": "http://172.15.0.21:2379",
     "networkd_address": "172.15.0.23/16",
     "networkd_dns": "172.15.0.3",
     "networkd_gateway": "172.15.0.1",

--- a/examples/groups/k8s/node3.json
+++ b/examples/groups/k8s/node3.json
@@ -1,6 +1,6 @@
 {
   "id": "node3",
-  "name": "Worker 2",
+  "name": "k8s worker",
   "profile": "k8s-worker",
   "selector": {
     "mac": "52:54:00:c3:61:77"
@@ -8,7 +8,6 @@
   "metadata": {
     "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
     "etcd_name": "node3",
-    "fleet_metadata": "role=etcd,name=node3",
     "ipv4_address": "172.15.0.23",
     "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
     "k8s_controller_endpoint": "https://172.15.0.21",

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -57,6 +57,7 @@ systemd:
         Requires=k8s-assets.target
         After=k8s-assets.target
         [Service]
+        Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         Environment=KUBELET_VERSION=v1.2.4_coreos.1
         ExecStart=/usr/lib/coreos/kubelet-wrapper \

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -14,13 +14,6 @@ systemd:
             Environment="ETCD_LISTEN_PEER_URLS=http://{{.ipv4_address}}:2380"
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
-    - name: fleet.service
-      enable: true
-      dropins:
-        - name: 40-fleet-metadata.conf
-          contents: |
-            [Service]
-            Environment="FLEET_METADATA={{.fleet_metadata}}"
     - name: flanneld.service
       dropins:
         - name: 40-ExecStartPre-symlink.conf

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -54,6 +54,7 @@ systemd:
         Requires=k8s-assets.target
         After=k8s-assets.target
         [Service]
+        Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         Environment=KUBELET_VERSION=v1.2.4_coreos.1
         ExecStart=/usr/lib/coreos/kubelet-wrapper \

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -7,13 +7,9 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_NAME={{.etcd_name}}"
-            Environment="ETCD_ADVERTISE_CLIENT_URLS=http://{{.ipv4_address}}:2379"
-            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.ipv4_address}}:2380"
+            Environment="ETCD_PROXY=on"
             Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379"
-            Environment="ETCD_LISTEN_PEER_URLS=http://{{.ipv4_address}}:2380"
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
-            Environment="ETCD_STRICT_RECONFIG_CHECK=true"
     - name: flanneld.service
       dropins:
         - name: 40-ExecStartPre-symlink.conf

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -14,13 +14,6 @@ systemd:
             Environment="ETCD_LISTEN_PEER_URLS=http://{{.ipv4_address}}:2380"
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
-    - name: fleet.service
-      enable: true
-      dropins:
-        - name: 40-fleet-metadata.conf
-          contents: |
-            [Service]
-            Environment="FLEET_METADATA={{.fleet_metadata}}"
     - name: flanneld.service
       dropins:
         - name: 40-ExecStartPre-symlink.conf


### PR DESCRIPTION
* examples/{k8s,k8s-install,k8s-docker}: Mount /etc/resolv.conf into kubelet
* Kubelet must be able to resolve DNS names which are known to the host. This fixes a bug in which only IP's could be used for `k8s_controller_endpoint` metadata
* Run etcd on the controller and proxies on the workers. This updates the `k8s`, `k8s-install`, and `k8s-docker` clusters to match the self-hosted Kuberntes setup (i.e. `bootkube`)
* Remove `fleet_metadata` for simplicity, it is not a requirement for Kubernetes

Updated clusters have been validated in local VMs and on physical hardware ala [dghubble/metal](https://github.com/dghubble/metal)
