### PR TITLE
bootcfg/http: Add structured info/debug logging

### DIFF
--- a/bootcfg/http/grub.go
+++ b/bootcfg/http/grub.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"text/template"
 
+	"github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 
@@ -24,9 +25,19 @@ func (s *Server) grubHandler() ContextHandler {
 	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 		profile, err := profileFromContext(ctx)
 		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"labels": labelsFromRequest(nil, req),
+			}).Infof("No matching profile")
 			http.NotFound(w, req)
 			return
 		}
+
+		// match was successful
+		s.logger.WithFields(logrus.Fields{
+			"labels":  labelsFromRequest(nil, req),
+			"profile": profile.Id,
+		}).Debug("Matched a GRUB config")
+
 		var buf bytes.Buffer
 		err = grubTemplate.Execute(&buf, profile.Boot)
 		if err != nil {

--- a/bootcfg/http/handlers.go
+++ b/bootcfg/http/handlers.go
@@ -39,7 +39,7 @@ func versionHandler() http.Handler {
 // logRequest logs HTTP requests.
 func (s *Server) logRequest(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
-		s.logger.Debugf("HTTP %s %v", req.Method, req.URL)
+		s.logger.Infof("HTTP %s %v", req.Method, req.URL)
 		next.ServeHTTP(w, req)
 	}
 	return http.HandlerFunc(fn)

--- a/bootcfg/http/http.go
+++ b/bootcfg/http/http.go
@@ -60,8 +60,11 @@ func labelsFromRequest(logger *logrus.Logger, req *http.Request) map[string]stri
 			if hw, err := parseMAC(values.Get(key)); err == nil {
 				labels[key] = hw.String()
 			} else {
-				// invalid MAC arguments may be common
-				logger.Debugf("error parsing MAC address: %s", err)
+				if logger != nil {
+					logger.WithFields(logrus.Fields{
+						"mac": values.Get(key),
+					}).Warningf("ignoring unparseable MAC address: %v", err)
+				}
 			}
 		default:
 			// matchers don't use multi-value keys, drop later values

--- a/bootcfg/http/ipxe.go
+++ b/bootcfg/http/ipxe.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"text/template"
 
+	"github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 
@@ -34,9 +35,19 @@ func (s *Server) ipxeHandler() ContextHandler {
 	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 		profile, err := profileFromContext(ctx)
 		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"labels": labelsFromRequest(nil, req),
+			}).Infof("No matching profile")
 			http.NotFound(w, req)
 			return
 		}
+
+		// match was successful
+		s.logger.WithFields(logrus.Fields{
+			"labels":  labelsFromRequest(nil, req),
+			"profile": profile.Id,
+		}).Debug("Matched an iPXE config")
+
 		var buf bytes.Buffer
 		err = ipxeTemplate.Execute(&buf, profile.Boot)
 		if err != nil {

--- a/bootcfg/http/pixiecore.go
+++ b/bootcfg/http/pixiecore.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"path/filepath"
 
+	"github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 
 	"github.com/coreos/coreos-baremetal/bootcfg/server"
@@ -15,23 +16,41 @@ import (
 // https://github.com/danderson/pixiecore/blob/master/README.api.md
 func (s *Server) pixiecoreHandler(core server.Server) ContextHandler {
 	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+		// pixiecore only provides a MAC address label
 		macAddr, err := parseMAC(filepath.Base(req.URL.Path))
 		if err != nil {
+			s.logger.Errorf("unparseable MAC address: %v", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		// pixiecore only provides MAC addresses
 		attrs := map[string]string{"mac": macAddr.String()}
+
 		group, err := core.SelectGroup(ctx, &pb.SelectGroupRequest{Labels: attrs})
 		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"label": macAddr,
+			}).Infof("No matching group")
 			http.NotFound(w, req)
 			return
 		}
+
 		profile, err := core.ProfileGet(ctx, &pb.ProfileGetRequest{Id: group.Profile})
 		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"label": macAddr,
+				"group": group.Id,
+			}).Infof("No profile named: %s", group.Profile)
 			http.NotFound(w, req)
 			return
 		}
+
+		// match was successful
+		s.logger.WithFields(logrus.Fields{
+			"label":   macAddr,
+			"group":   group.Id,
+			"profile": profile.Id,
+		}).Debug("Matched a Pixiecore config")
+
 		s.renderJSON(w, profile.Boot)
 	}
 	return ContextHandlerFunc(fn)

--- a/bootcfg/http/pixiecore_test.go
+++ b/bootcfg/http/pixiecore_test.go
@@ -19,7 +19,8 @@ func TestPixiecoreHandler(t *testing.T) {
 		Groups:   map[string]*storagepb.Group{testGroupWithMAC.Id: testGroupWithMAC},
 		Profiles: map[string]*storagepb.Profile{testGroupWithMAC.Profile: fake.Profile},
 	}
-	srv := NewServer(&Config{})
+	logger, _ := logtest.NewNullLogger()
+	srv := NewServer(&Config{Logger: logger})
 	c := server.NewServer(&server.Config{Store: store})
 	h := srv.pixiecoreHandler(c)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Now that we've switched to Logrus (#254) we can make use of its structured fields.

* Add info logs for errors matching machine groups or resolving profiles, or supported templates
* Add debug logs with successful match info

Here are a few examples:

If a query does not match any group's selectors:

```
[44542.643080] bootcfg[5]: time="2016-07-12T17:04:14Z" level=info msg="No matching group" labels=map[mac:52:54:00:a1:9b:ad]
```

If the group typo's the name of the profile (should be `k8s-master` not `k8s-meister`):

```
[44637.346291] bootcfg[5]: time="2016-07-12T17:05:48Z" level=info msg="No profile named: k8s-meister" group=node1 group_name="k8s controller" labels=map[mac:52:54:00:a1:9c:ae]
```

If a config (ipxe, grub, Ignition, cloud-config, generic) referenced in a profile is missing:

```
[44806.683946] bootcfg[5]: time="2016-07-12T17:08:38Z" level=info msg="No Ignition or Fuze template named: k8s-meister.yaml" group=node1 group_name="k8s controller" labels=map[mac:52:54:00:a1:9c:ae] profile=k8s-master
```

Logs from a local `k8s` cluster bring-up with debug logging showing successful matches:

```
[21473.163947] bootcfg[5]: time="2016-07-12T10:36:24Z" level=info msg="starting bootcfg HTTP server on 0.0.0.0:8080"
[21498.750627] bootcfg[5]: time="2016-07-12T10:36:50Z" level=info msg="HTTP GET /boot.ipxe"
[21498.772398] bootcfg[5]: time="2016-07-12T10:36:50Z" level=info msg="HTTP GET /ipxe?uuid=5c7e488c-5eca-45ea-b085-b4d1ce8e5d86&mac=52-54-00-a1-9c-ae&domain=&hostname=&serial="
[21498.773845] bootcfg[5]: time="2016-07-12T10:36:50Z" level=debug msg="Matched an iPXE config" labels=map[mac:52:54:00:a1:9c:ae domain: hostname: serial: uuid:5c7e488c-5eca-45ea-b085-b4d1ce8e5d86] profile=k8s-master
[21498.781756] bootcfg[5]: time="2016-07-12T10:36:50Z" level=info msg="HTTP GET /assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz"
[21501.604807] bootcfg[5]: time="2016-07-12T10:36:53Z" level=info msg="HTTP GET /boot.ipxe"
[21501.640737] bootcfg[5]: time="2016-07-12T10:36:53Z" level=info msg="HTTP GET /ipxe?uuid=574e7aae-fda5-43a6-80f9-615c5c75f83b&mac=52-54-00-b2-2f-86&domain=&hostname=&serial="
[21501.642327] bootcfg[5]: time="2016-07-12T10:36:53Z" level=debug msg="Matched an iPXE config" labels=map[uuid:574e7aae-fda5-43a6-80f9-615c5c75f83b mac:52:54:00:b2:2f:86 domain: hostname: serial:] profile=k8s-worker
[21501.650795] bootcfg[5]: time="2016-07-12T10:36:53Z" level=info msg="HTTP GET /assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz"
[21501.653321] bootcfg[5]: time="2016-07-12T10:36:53Z" level=info msg="HTTP GET /boot.ipxe"
[21501.664211] bootcfg[5]: time="2016-07-12T10:36:53Z" level=info msg="HTTP GET /ipxe?uuid=d74ddf0c-29dd-4a3e-8d54-b7b9a985a9ee&mac=52-54-00-c3-61-77&domain=&hostname=&serial="
[21501.664998] bootcfg[5]: time="2016-07-12T10:36:53Z" level=debug msg="Matched an iPXE config" labels=map[uuid:d74ddf0c-29dd-4a3e-8d54-b7b9a985a9ee mac:52:54:00:c3:61:77 domain: hostname: serial:] profile=k8s-worker
[21501.670834] bootcfg[5]: time="2016-07-12T10:36:53Z" level=info msg="HTTP GET /assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz"
[21502.096573] bootcfg[5]: time="2016-07-12T10:36:53Z" level=info msg="HTTP GET /assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"
[21502.790742] bootcfg[5]: time="2016-07-12T10:36:54Z" level=info msg="HTTP GET /assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"
[21502.992957] bootcfg[5]: time="2016-07-12T10:36:54Z" level=info msg="HTTP GET /assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"
[21524.489314] bootcfg[5]: time="2016-07-12T10:37:16Z" level=info msg="HTTP GET /ignition?uuid=d74ddf0c-29dd-4a3e-8d54-b7b9a985a9ee&mac=52-54-00-c3-61-77"
[21524.490071] bootcfg[5]: time="2016-07-12T10:37:16Z" level=debug msg="Matched an Ignition or Fuze template" group=node3 labels=map[uuid:d74ddf0c-29dd-4a3e-8d54-b7b9a985a9ee mac:52:54:00:c3:61:77] profile=k8s-worker
[21525.654098] bootcfg[5]: time="2016-07-12T10:37:17Z" level=info msg="HTTP GET /ignition?uuid=5c7e488c-5eca-45ea-b085-b4d1ce8e5d86&mac=52-54-00-a1-9c-ae"
[21525.654533] bootcfg[5]: time="2016-07-12T10:37:17Z" level=debug msg="Matched an Ignition or Fuze template" group=node1 labels=map[uuid:5c7e488c-5eca-45ea-b085-b4d1ce8e5d86 mac:52:54:00:a1:9c:ae] profile=k8s-master
[21525.986399] bootcfg[5]: time="2016-07-12T10:37:17Z" level=info msg="HTTP GET /ignition?uuid=574e7aae-fda5-43a6-80f9-615c5c75f83b&mac=52-54-00-b2-2f-86"
[21525.987061] bootcfg[5]: time="2016-07-12T10:37:17Z" level=debug msg="Matched an Ignition or Fuze template" group=node2 labels=map[uuid:574e7aae-fda5-43a6-80f9-615c5c75f83b mac:52:54:00:b2:2f:86] profile=k8s-worker
[21543.207828] bootcfg[5]: time="2016-07-12T10:37:34Z" level=info msg="HTTP GET /assets/tls/ca.pem"
[21543.225757] bootcfg[5]: time="2016-07-12T10:37:34Z" level=info msg="HTTP GET /assets/tls/worker.pem"
[21543.226476] bootcfg[5]: time="2016-07-12T10:37:34Z" level=info msg="HTTP GET /assets/tls/worker-key.pem"
[21544.554105] bootcfg[5]: time="2016-07-12T10:37:36Z" level=info msg="HTTP GET /assets/tls/ca.pem"
[21544.562028] bootcfg[5]: time="2016-07-12T10:37:36Z" level=info msg="HTTP GET /assets/tls/apiserver.pem"
[21544.569392] bootcfg[5]: time="2016-07-12T10:37:36Z" level=info msg="HTTP GET /assets/tls/apiserver-key.pem"
[21545.920765] bootcfg[5]: time="2016-07-12T10:37:37Z" level=info msg="HTTP GET /assets/tls/worker.pem"
[21545.921038] bootcfg[5]: time="2016-07-12T10:37:37Z" level=info msg="HTTP GET /assets/tls/ca.pem"
[21545.934591] bootcfg[5]: time="2016-07-12T10:37:37Z" level=info msg="HTTP GET /assets/tls/worker-key.pem"
```

Closes #233 
cc @joeatwork @rothgar 