### PR TITLE
bootcfg/http: Add request query values to template variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
     * Error when a template is rendered with a machine Group which is missing a metadata value. Previously, missing values defaulted to "no value" (#210)
 * Add/improve rkt, Docker, Kubernetes, and binary/systemd deployment docs
 * Add DialTimeout to gRPC client config (#273)
+* Allow query parameters to be used as template variables as `{{.request.query.foo}}` (#182)
 
 #### Changes
 
@@ -25,6 +26,7 @@
     - [Migrate from bootcfg v0.3.0](Documentation/ignition.md#migration-from-v030)
     - Require CoreOS 1010.1.0 or newer
     - Drop support for Ignition v1 format
+* Replace template variable `{{.query}}` with `{{.request.raw_query}}` (**breaking**)
 
 #### Examples
 

--- a/bootcfg/http/generic.go
+++ b/bootcfg/http/generic.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -56,18 +55,11 @@ func (s *Server) genericHandler(core server.Server) ContextHandler {
 		}).Debug("Matched a generic template")
 
 		// collect data for rendering
-		data := make(map[string]interface{})
-		if group.Metadata != nil {
-			err = json.Unmarshal(group.Metadata, &data)
-			if err != nil {
-				s.logger.Errorf("error unmarshalling metadata: %v", err)
-				http.NotFound(w, req)
-				return
-			}
-		}
-		data["query"] = req.URL.RawQuery
-		for key, value := range group.Selector {
-			data[strings.ToLower(key)] = value
+		data, err := collectVariables(req, group)
+		if err != nil {
+			s.logger.Errorf("error collecting variables: %v", err)
+			http.NotFound(w, req)
+			return
 		}
 
 		// render the template of a generic config with data

--- a/bootcfg/http/generic_test.go
+++ b/bootcfg/http/generic_test.go
@@ -18,10 +18,12 @@ func TestGenericHandler(t *testing.T) {
 	content := `#foo-bar-baz template
 UUID={{.uuid}}
 SERVICE={{.service_name}}
+FOO={{.request.query.foo}}
 `
 	expected := `#foo-bar-baz template
 UUID=a1b2c3d4
 SERVICE=etcd2
+FOO=some-param
 `
 	store := &fake.FixedStore{
 		Profiles:       map[string]*storagepb.Profile{fake.Group.Profile: fake.Profile},
@@ -33,10 +35,10 @@ SERVICE=etcd2
 	h := srv.genericHandler(c)
 	ctx := withGroup(context.Background(), fake.Group)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req, _ := http.NewRequest("GET", "/?foo=some-param", nil)
 	h.ServeHTTP(ctx, w, req)
 	// assert that:
-	// - Generic config is rendered with Group metadata and selectors
+	// - Generic config is rendered with Group selectors, metadata, and query variables
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, expected, w.Body.String())
 }
@@ -82,6 +84,6 @@ KEY={{.missing_key}}
 	h.ServeHTTP(ctx, w, req)
 	// assert that:
 	// - Generic template rendering errors because "missing_key" is not
-	// present in the Group metadata
+	// present in the template variables
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/bootcfg/http/ignition.go
+++ b/bootcfg/http/ignition.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -74,18 +73,11 @@ func (s *Server) ignitionHandler(core server.Server) ContextHandler {
 		// Fuze Config template
 
 		// collect data for rendering
-		data := make(map[string]interface{})
-		if group.Metadata != nil {
-			err = json.Unmarshal(group.Metadata, &data)
-			if err != nil {
-				s.logger.Errorf("error unmarshalling metadata: %v", err)
-				http.NotFound(w, req)
-				return
-			}
-		}
-		data["query"] = req.URL.RawQuery
-		for key, value := range group.Selector {
-			data[strings.ToLower(key)] = value
+		data, err := collectVariables(req, group)
+		if err != nil {
+			s.logger.Errorf("error collecting variables: %v", err)
+			http.NotFound(w, req)
+			return
 		}
 
 		// render the template for an Ignition config with data

--- a/bootcfg/http/metadata.go
+++ b/bootcfg/http/metadata.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -31,18 +30,12 @@ func (s *Server) metadataHandler() ContextHandler {
 			"group":  group.Id,
 		}).Debug("Matched group metadata")
 
-		// collect data for response
-		data := make(map[string]interface{})
-		if group.Metadata != nil {
-			err = json.Unmarshal(group.Metadata, &data)
-			if err != nil {
-				s.logger.Errorf("error unmarshalling metadata: %v", err)
-				http.NotFound(w, req)
-				return
-			}
-		}
-		for key, value := range group.Selector {
-			data[key] = value
+		// collect data for rendering
+		data, err := collectVariables(req, group)
+		if err != nil {
+			s.logger.Errorf("error collecting variables: %v", err)
+			http.NotFound(w, req)
+			return
 		}
 
 		w.Header().Set(contentType, plainContentType)

--- a/bootcfg/http/metadata_test.go
+++ b/bootcfg/http/metadata_test.go
@@ -12,24 +12,32 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/coreos/coreos-baremetal/bootcfg/storage/storagepb"
-	fake "github.com/coreos/coreos-baremetal/bootcfg/storage/testfakes"
 )
 
 func TestMetadataHandler(t *testing.T) {
+	group := &storagepb.Group{
+		Id:       "test-group",
+		Selector: map[string]string{"mac": "52:54:00:a1:9c:ae"},
+		Metadata: []byte(`{"meta":"data", "etcd":{"name":"node1"},"some":{"nested":{"data":"some-value"}}}`),
+	}
 	logger, _ := logtest.NewNullLogger()
 	srv := NewServer(&Config{Logger: logger})
 	h := srv.metadataHandler()
-	ctx := withGroup(context.Background(), fake.Group)
+	ctx := withGroup(context.Background(), group)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/?uuid=a1b2c3d4", nil)
+	req, _ := http.NewRequest("GET", "/?mac=52-54-00-a1-9c-ae", nil)
 	h.ServeHTTP(ctx, w, req)
 	// assert that:
 	// - the Group's custom metadata and selectors are served
 	// - key names are upper case
 	expectedData := map[string]string{
-		"POD_NETWORK":  "10.2.0.0/16",
-		"SERVICE_NAME": "etcd2",
-		"UUID":         "a1b2c3d4",
+		// group metadata
+		"META": "data",
+		"ETCD": "map[name:node1]",
+		"SOME": "map[nested:map[data:some-value]]",
+		// group selector
+		"MAC": "52:54:00:a1:9c:ae",
+		// HACK(dghubble): Not testing query params until #84
 	}
 	assert.Equal(t, http.StatusOK, w.Code)
 	// convert response (random order) to map (tests compare in order)
@@ -57,11 +65,11 @@ func TestMetadataHandler_MetadataEdgeCases(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
 		h.ServeHTTP(ctx, w, req)
-		// assert that:
-		// - the Group's custom metadata is served
+		// assert that each Group's metadata is formatted:
 		// - key names are upper case
+		// - key/value pairs are newline separated
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, c.expected, w.Body.String())
+		assert.Contains(t, w.Body.String(), c.expected)
 		assert.Equal(t, plainContentType, w.HeaderMap.Get(contentType))
 	}
 }
@@ -85,6 +93,10 @@ func metadataToMap(metadata string) map[string]string {
 		token := scanner.Text()
 		pair := strings.SplitN(token, "=", 2)
 		if len(pair) != 2 {
+			continue
+		}
+		// HACK(dghubble) - Skip map unwinding until #84
+		if pair[0] == "REQUEST" {
 			continue
 		}
 		data[pair[0]] = pair[1]

--- a/examples/ignition/install-reboot.yaml
+++ b/examples/ignition/install-reboot.yaml
@@ -20,7 +20,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl "{{.ignition_endpoint}}?{{.query}}&os=installed" -o ignition.json
+          curl "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
           coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}}
           udevadm settle
           systemctl reboot

--- a/examples/ignition/install-shutdown.yaml
+++ b/examples/ignition/install-shutdown.yaml
@@ -20,7 +20,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl "{{.ignition_endpoint}}?{{.query}}&os=installed" -o ignition.json
+          curl "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
           coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}}
           udevadm settle
           systemctl poweroff


### PR DESCRIPTION
* Add query parameters to template variables, referenced by `{{.request.query.param}}`
* Render Ignition/Fuze, cloud-config, and generic templates and metadata with collected variables
* Replace template variable {{.query}} with {{.request.raw_query}} (breaking)

rel. #182