### PR TITLE
examples: Update CoreOS version and bootkube

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -32,8 +32,8 @@ Finds the profile for the machine and renders the network boot config (kernel, o
 **Response**
 
     #!ipxe
-    kernel /assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz coreos.config.url=http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.first_boot=1 coreos.autologin
-    initrd  /assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz
+    kernel /assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz coreos.config.url=http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.first_boot=1 coreos.autologin
+    initrd  /assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz
     boot
 
 ## GRUB2
@@ -56,9 +56,9 @@ Finds the profile for the machine and renders the network boot config as a GRUB 
     timeout=1
     menuentry "CoreOS" {
     echo "Loading kernel"
-    linuxefi "(http;bootcfg.foo:8080)/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://bootcfg.foo:8080/ignition" "coreos.first_boot"
+    linuxefi "(http;bootcfg.foo:8080)/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://bootcfg.foo:8080/ignition" "coreos.first_boot"
     echo "Loading initrd"
-    initrdefi "(http;bootcfg.foo:8080)/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"
+    initrdefi "(http;bootcfg.foo:8080)/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"
     }
 
 ## Pixiecore
@@ -76,8 +76,8 @@ Finds the profile matching the machine and renders the network boot config as JS
 **Response**
 
     {
-      "kernel":"/assets/coreos/1032.0.0/coreos_production_pxe.vmlinuz",
-      "initrd":["/assets/coreos/1032.0.0/coreos_production_pxe_image.cpio.gz"],
+      "kernel":"/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+      "initrd":["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
       "cmdline":{
         "cloud-config-url":"http://bootcfg.foo/cloud?mac=ADDRESS",
         "coreos.autologin":""
@@ -225,10 +225,10 @@ If you need to serve static assets (e.g. kernel, initrd), `bootcfg` can serve ar
 
     bootcfg.foo/assets/
     └── coreos
-        └── 1053.2.0
+        └── 1109.1.0
             ├── coreos_production_pxe.vmlinuz
             └── coreos_production_pxe_image.cpio.gz
-        └── 1032.0.0
+        └── 1053.2.0
             ├── coreos_production_pxe.vmlinuz
             └── coreos_production_pxe_image.cpio.gz
 

--- a/Documentation/bootcfg.md
+++ b/Documentation/bootcfg.md
@@ -62,8 +62,8 @@ Profiles reference an Ignition config, Cloud-Config, and/or generic config by na
       "ignition_id": "etcd.yaml"
       "generic_id": "some-service.cfg",
       "boot": {
-        "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+        "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+        "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
         "cmdline": {
           "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
           "coreos.autologin": "",

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,7 +1,7 @@
 
 # Self-Hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node Kubernetes v1.3.0-beta.2 cluster with etcd, flannel, and a special "runonce" host Kublet. The CoreOS [bootkube](https://github.com/coreos/bootkube) tool is used to bootstrap kubelet, apiserver, scheduler, and controller-manager as pods, which can be managed via kubectl. `bootkube start` is run on any controller (master) to create a temporary control-plane and start Kubernetes components initially. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node Kubernetes v1.3.0 cluster with etcd, flannel, and a special "runonce" host Kublet. The CoreOS [bootkube](https://github.com/coreos/bootkube) tool is used to bootstrap kubelet, apiserver, scheduler, and controller-manager as pods, which can be managed via kubectl. `bootkube start` is run on any controller (master) to create a temporary control-plane and start Kubernetes components initially. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Experimental
 
@@ -15,7 +15,7 @@ Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) g
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
 
-Build and install [bootkube](https://github.com/coreos/bootkube/releases) v0.1.1.
+Build and install [bootkube](https://github.com/coreos/bootkube/releases) v0.1.2.
 
 ## Examples
 

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -28,7 +28,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 1053.2.0 ./examples/assets
+    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -24,7 +24,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
 
 Download CoreOS image assets referenced by the `etcd-docker` [example](../examples) to `examples/assets`.
 
-    ./scripts/get-coreos alpha 1053.2.0 ./examples/assets
+    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
 
 ## Containers
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -26,7 +26,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
 
 Download CoreOS image assets referenced by the `etcd` [example](../examples) to `examples/assets`.
 
-    ./scripts/get-coreos alpha 1053.2.0 ./examples/assets
+    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
 
 Define the `metal0` virtual bridge with [CNI](https://github.com/appc/cni).
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -24,7 +24,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 1053.2.0 ./examples/assets
+    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 

--- a/Documentation/torus.md
+++ b/Documentation/torus.md
@@ -22,7 +22,7 @@ The [examples](..examples) statically assign IP addresses (172.15.0.21, 172.15.0
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 1053.2.0 ./examples/assets
+    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
 
 ## Containers
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,16 +5,16 @@ These examples network boot and provision machines into CoreOS clusters using `b
 
 | Name       | Description | CoreOS Version | FS | Docs | 
 |------------|-------------|----------------|----|-----------|
-| pxe | CoreOS via iPXE | alpha/1053.2.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| grub | CoreOS via GRUB2 Netboot | alpha/1053.2.0 | RAM | NA |
-| pxe-disk | CoreOS via iPXE, with a root filesystem | alpha/1053.2.0 | Disk | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| etcd, etcd-docker | iPXE boot a 3 node etcd cluster and proxy | alpha/1053.2.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
-| etcd-install | Install a 3-node etcd cluster to disk | alpha/1053.2.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
-| k8s, k8s-docker | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1053.2.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| k8s-install | Install a Kubernetes cluster to disk | alpha/1053.2.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1053.2.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1053.2.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| torus | Torus distributed storage | alpha/1053.2.0 | Disk | [tutorial](../Documentation/torus.md) |
+| pxe | CoreOS via iPXE | alpha/1109.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| grub | CoreOS via GRUB2 Netboot | alpha/1109.1.0 | RAM | NA |
+| pxe-disk | CoreOS via iPXE, with a root filesystem | alpha/1109.1.0 | Disk | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| etcd, etcd-docker | iPXE boot a 3 node etcd cluster and proxy | alpha/1109.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
+| etcd-install | Install a 3-node etcd cluster to disk | alpha/1109.1.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
+| k8s, k8s-docker | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| k8s-install | Install a Kubernetes cluster to disk | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| torus | Torus distributed storage | alpha/1109.1.0 | Disk | [tutorial](../Documentation/torus.md) |
 
 ## Tutorials
 

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "1053.2.0",
+    "coreos_version": "1109.1.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/etcd-install/install.json
+++ b/examples/groups/etcd-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "1053.2.0",
+    "coreos_version": "1109.1.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/k8s-install/install.json
+++ b/examples/groups/k8s-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "1053.2.0",
+    "coreos_version": "1109.1.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/ignition/bootkube-master.yaml
+++ b/examples/ignition/bootkube-master.yaml
@@ -46,7 +46,7 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+        Environment=KUBELET_VERSION=v1.3.0_coreos.1
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
@@ -111,7 +111,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.1.1}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.1.2}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/home/core/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -41,7 +41,7 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.3.0-beta.2_coreos.0
+        Environment=KUBELET_VERSION=v1.3.0_coreos.1
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests

--- a/examples/profiles/bootkube-master.json
+++ b/examples/profiles/bootkube-master.json
@@ -2,8 +2,8 @@
   "id": "bootkube-master",
   "name": "bootkube Ready Master",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -2,8 +2,8 @@
   "id": "bootkube-worker",
   "name": "bootkube Ready Worker",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/etcd-proxy.json
+++ b/examples/profiles/etcd-proxy.json
@@ -2,8 +2,8 @@
   "id": "etcd-proxy",
   "name": "etcd-proxy",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/etcd.json
+++ b/examples/profiles/etcd.json
@@ -2,8 +2,8 @@
   "id": "etcd",
   "name": "etcd",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/grub.json
+++ b/examples/profiles/grub.json
@@ -2,8 +2,8 @@
   "id": "grub",
   "name": "CoreOS via GRUB2",
   "boot": {
-    "kernel": "(http;bootcfg.foo:8080)/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["(http;bootcfg.foo:8080)/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "(http;bootcfg.foo:8080)/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["(http;bootcfg.foo:8080)/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition",
       "coreos.autologin": "",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -2,8 +2,8 @@
   "id": "install-reboot",
   "name": "Install CoreOS and Reboot",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/install-shutdown.json
+++ b/examples/profiles/install-shutdown.json
@@ -2,8 +2,8 @@
   "id": "install-shutdown",
   "name": "Install CoreOS and Shutdown",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-master-install.json
+++ b/examples/profiles/k8s-master-install.json
@@ -2,8 +2,8 @@
   "id": "k8s-master-install",
   "name": "Kubernetes Master Install",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-master.json
+++ b/examples/profiles/k8s-master.json
@@ -2,8 +2,8 @@
   "id": "k8s-master",
   "name": "Kubernetes Master",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/k8s-worker-install.json
+++ b/examples/profiles/k8s-worker-install.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker-install",
   "name": "Kubernetes Worker Install",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-worker.json
+++ b/examples/profiles/k8s-worker.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/pxe-disk.json
+++ b/examples/profiles/pxe-disk.json
@@ -2,8 +2,8 @@
   "id": "pxe-disk",
   "name": "CoreOS with SSH",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/pxe.json
+++ b/examples/profiles/pxe.json
@@ -3,8 +3,8 @@
 	"name": "CoreOS with SSH",
 	"ignition_id": "ssh.yaml",
 	"boot": {
-		"kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-		"initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+		"kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+		"initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
 		"cmdline": {
 			"coreos.autologin": "",
 			"coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/torus.json
+++ b/examples/profiles/torus.json
@@ -2,8 +2,8 @@
   "id": "torus",
   "name": "torus",
   "boot": {
-    "kernel": "/assets/coreos/1053.2.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1053.2.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,7 @@ This will create:
 
     examples/assets/
     └── coreos
-        └── 1053.2.0
+        └── 1109.1.0
             ├── CoreOS_Image_Signing_Key.asc
             ├── coreos_production_image.bin.bz2
             ├── coreos_production_image.bin.bz2.sig

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -4,7 +4,7 @@
 set -eou pipefail
 
 CHANNEL=${1:-"alpha"}
-VERSION=${2:-"1053.2.0"}
+VERSION=${2:-"1109.1.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 DEST=$DEST_DIR/coreos/$VERSION
 BASE_URL=https://$CHANNEL.release.core-os.net/amd64-usr/$VERSION


### PR DESCRIPTION
* Bump CoreOS Alpha from 1053.2.0 to 1109.1.0. Clusters which install to disk auto-update, so this bump just changes the "starting" version. Deployed alpha clusters should already be using 1109.1.0.
* Update self-hosted Kubernetes cluster example to use bootkube v0.1.2.
* Bump Kubernetes from v1.3.0-beta.2_coreos.0 to v1.3.0_coreos.1

cc @aaronlevy 