### PR TITLE
examples/torus: Use DNS names for Torus cluster

### DIFF
--- a/Documentation/torus.md
+++ b/Documentation/torus.md
@@ -7,14 +7,14 @@ The Torus example provisions a 3 node CoreOS cluster, with `etcd3` and Torus, to
 
 Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) guide and understand the basics. In particular, you should be able to:
 
-* Use rkt to start `bootcfg`
+* Use rkt or Docker to start `bootcfg`
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
 * Install the Torus [binaries](https://github.com/coreos/torus/releases)
 
 ## Examples
 
-The [examples](..examples) statically assign IP addresses (172.15.0.21, 172.15.0.22, 172.15.0.23) to libvirt client VMs created by `scripts/libvirt`. The examples can be used for physical machines if you update the MAC/IP addresses. See [network setup](network-setup.md) and [deployment](deployment.md).
+The [examples](..examples) statically assign IP addresses to libvirt client VMs created by `scripts/libvirt`. The examples can be used for physical machines if you update the MAC/IP addresses. See [network setup](network-setup.md) and [deployment](deployment.md).
 
 * [torus](../examples/groups/torus) - iPXE boot a Torus cluster (use rkt)
 
@@ -41,13 +41,14 @@ Install the Torus [binaries](https://github.com/coreos/torus/releases) on your l
 Run `list-peers` to report the status of data nodes in the Torus cluster.
 
 ```
-+--------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
-|         ADDRESS          |                 UUID                 |  SIZE   | USED | MEMBER |    UPDATED    | REB/REP DATA |
-+--------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
-| http://172.15.0.21:40000 | 016fad6a-2e23-11e6-8ced-525400a19cae | 1.0 GiB | 0 B  | OK     | 1 second ago  | 0 B/sec      |
-| http://172.15.0.23:40000 | 0408cbba-2e23-11e6-9871-525400c36177 | 1.0 GiB | 0 B  | OK     | 2 seconds ago | 0 B/sec      |
-| http://172.15.0.22:40000 | 0c67d31c-2e23-11e6-91f5-525400b22f86 | 1.0 GiB | 0 B  | OK     | 3 seconds ago | 0 B/sec      |
-+--------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
++--------------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
+|            ADDRESS             |                 UUID                 |  SIZE   | USED | MEMBER |    UPDATED    | REB/REP DATA |
++--------------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
+| http://node1.example.com:40000 | 67145622-52cb-11e6-a886-525400a19cae | 1.0 GiB | 0 B  | OK     | 2 seconds ago | 0 B/sec      |
+| http://node2.example.com:40000 | 6978182a-52cb-11e6-b41d-525400b22f86 | 1.0 GiB | 0 B  | OK     | 3 seconds ago | 0 B/sec      |
+| http://node3.example.com:40000 | 6e0e4d7d-52cb-11e6-af25-525400c36177 | 1.0 GiB | 0 B  | OK     | now           | 0 B/sec      |
++--------------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
+
 ```
 
 Torus has already initialized its metadata within etcd3 to format the cluster and added all peers to the pool. Each node provides 1 GiB of storage and has `MEMBER` status `OK`.
@@ -56,7 +57,7 @@ Torus has already initialized its metadata within etcd3 to format the cluster an
 
 Create a new replicated, virtual block device or `volume` on Torus.
 
-    ./torusblk --etcd=172.15.0.21:2379 volume create hello 500MiB
+    ./torusctl block create --etcd=172.15.0.21:2379 hello 500MiB
 
 List the current volumes,
 

--- a/examples/groups/torus/node1.json
+++ b/examples/groups/torus/node1.json
@@ -6,12 +6,9 @@
     "mac": "52:54:00:a1:9c:ae"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
+    "domain_name": "node1.example.com",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380",
     "etcd_name": "node1",
-    "ipv4_address": "172.15.0.21",
-    "networkd_address": "172.15.0.21/16",
-    "networkd_dns": "172.15.0.3",
-    "networkd_gateway": "172.15.0.1",
     "pxe": "true",
     "torus_storage_size": "1GiB"
   }

--- a/examples/groups/torus/node2.json
+++ b/examples/groups/torus/node2.json
@@ -6,12 +6,9 @@
     "mac": "52:54:00:b2:2f:86"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
+    "domain_name": "node2.example.com",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380",
     "etcd_name": "node2",
-    "ipv4_address": "172.15.0.22",
-    "networkd_address": "172.15.0.22/16",
-    "networkd_dns": "172.15.0.3",
-    "networkd_gateway": "172.15.0.1",
     "pxe": "true",
     "torus_storage_size": "1GiB"
   }

--- a/examples/groups/torus/node3.json
+++ b/examples/groups/torus/node3.json
@@ -6,12 +6,9 @@
     "mac": "52:54:00:c3:61:77"
   },
   "metadata": {
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380",
+    "domain_name": "node3.example.com",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380",
     "etcd_name": "node3",
-    "ipv4_address": "172.15.0.23",
-    "networkd_address": "172.15.0.23/16",
-    "networkd_dns": "172.15.0.3",
-    "networkd_gateway": "172.15.0.1",
     "pxe": "true",
     "torus_storage_size": "1GiB"
   }

--- a/examples/ignition/torus.yaml
+++ b/examples/ignition/torus.yaml
@@ -14,10 +14,10 @@ systemd:
         ExecStart=/usr/bin/docker run \
           --net=host \
           -e ETCD_NAME={{.etcd_name}} \
-          -e ETCD_ADVERTISE_CLIENT_URLS=http://{{.ipv4_address}}:2379 \
-          -e ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.ipv4_address}}:2380 \
+          -e ETCD_ADVERTISE_CLIENT_URLS=http://{{.domain_name}}:2379 \
+          -e ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.domain_name}}:2380 \
           -e ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379 \
-          -e ETCD_LISTEN_PEER_URLS=http://{{.ipv4_address}}:2380 \
+          -e ETCD_LISTEN_PEER_URLS=http://{{.domain_name}}:2380 \
           -e ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}} \
           -e ETCD_DATA_DIR=/var/lib/etcd3 \
           quay.io/coreos/etcd:v3.0.1
@@ -41,7 +41,7 @@ systemd:
           --net=host \
           -v /srv/torus:/data \
           -e STORAGE_SIZE={{.torus_storage_size}} \
-          -e LISTEN_HOST={{.ipv4_address}} \
+          -e LISTEN_HOST={{.domain_name}} \
           -e ETCD_HOST=127.0.0.1 \
           -e ETCD_PORT=2379 \
           -e AUTO_JOIN=1 \
@@ -75,19 +75,6 @@ storage:
         device: "/dev/disk/by-label/ROOT"
         format: "ext4"
   {{end}}
-
-{{ if not (index . "skip_networkd") }}
-networkd:
-  units:
-    - name: 10-static.network
-      contents: |
-        [Match]
-        MACAddress={{.mac}}
-        [Network]
-        Gateway={{.networkd_gateway}}
-        DNS={{.networkd_dns}}
-        Address={{.networkd_address}}
-{{end}}
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:


### PR DESCRIPTION
* Also change `torusblk volume create` to `torusctl block create`

cc @barakmich 
rel #291 