### PR TITLE
Add ARM to release architectures

### DIFF
--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -96,9 +96,11 @@ $ sudo systemctl start bootcfg.service
 
 ### General Linux
 
-Pre-build binaries are available for general Linux distributions. Copy the `bootcfg` static binary to an appropriate location on the host.
+Pre-built binaries are available for general Linux distributions.
 
 #### Binary
+
+Copy the `bootcfg` static binary to an appropriate location on the host.
 
 ```sh
 $ sudo cp bootcfg /usr/local/bin
@@ -123,7 +125,7 @@ $ sudo cp contrib/systemd/bootcfg.service /etc/systemd/system/
 $ sudo systemctl daemon-reload
 ```
 
-The example systemd unit exposes the `bootcfg` HTTP machine endpoints on port 8080 and the (optional) gRPC API on port 8081 (remove the `-rpc-address` flag if you don't need the gRPC API). Customize the port settings to suit your preferences and be sure to allow your choices within the host's firewall so clients can access the services.
+The example unit exposes the `bootcfg` HTTP machine endpoints on port 8080 and the (optional) gRPC API on port 8081 (remove the `-rpc-address` flag if you don't need the gRPC API). Customize the port settings to suit your preferences and be sure to allow your choices within the host's firewall so clients can access the services.
 
 #### Start bootcfg
 
@@ -136,7 +138,7 @@ $ sudo systemctl start bootcfg.service
 
 ## Verify
 
-Check the bootcfg service can be reached by client machines (those being provisioned).
+Verify the bootcfg service can be reached by client machines (those being provisioned).
 
 
 ```sh

--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,44 @@ install:
 	cp bin/bootcfg $(LOCAL_BIN)
 	cp bin/bootcmd $(LOCAL_BIN)
 
-release: clean _output/coreos-baremetal-linux-amd64.tar.gz _output/coreos-baremetal-darwin-amd64.tar.gz
+release: \
+	clean \
+	_output/coreos-baremetal-linux-amd64.tar.gz \
+	_output/coreos-baremetal-linux-arm.tar.gz \
+	_output/coreos-baremetal-linux-arm64.tar.gz \
+	_output/coreos-baremetal-darwin-amd64.tar.gz \
 
-bin/%/bootcfg:
-	GOOS=$* go build -o bin/$*/bootcfg -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcfg
+# bootcfg
 
-bin/%/bootcmd:
-	GOOS=$* go build -o bin/$*/bootcmd -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcmd
+bin/linux-amd64/bootcfg:
+	GOOS=linux GOARCH=amd64 go build -o bin/linux-amd64/bootcfg -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcfg
 
-_output/coreos-baremetal-%-amd64.tar.gz: NAME=coreos-baremetal-$(VERSION)-$*-amd64
-_output/coreos-baremetal-%-amd64.tar.gz: DEST=_output/$(NAME)
-_output/coreos-baremetal-%-amd64.tar.gz: bin/%/bootcfg bin/%/bootcmd
+bin/linux-arm/bootcfg:
+	GOOS=linux GOARCH=arm go build -o bin/linux-arm/bootcfg -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcfg
+
+bin/linux-arm64/bootcfg:
+	GOOS=linux GOARCH=arm64 go build -o bin/linux-arm64/bootcfg -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcfg
+
+bin/darwin-amd64/bootcfg:
+	GOOS=darwin GOARCH=amd64 go build -o bin/darwin-amd64/bootcfg -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcfg
+
+# bootcmd
+
+bin/linux-amd64/bootcmd:
+	GOOS=linux GOARCH=amd64 go build -o bin/linux-amd64/bootcmd -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcmd
+
+bin/linux-arm/bootcmd:
+	GOOS=linux GOARCH=arm go build -o bin/linux-arm/bootcmd -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcmd
+
+bin/linux-arm64/bootcmd:
+	GOOS=linux GOARCH=arm64 go build -o bin/linux-arm64/bootcmd -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcmd
+
+bin/darwin-amd64/bootcmd:
+	GOOS=darwin GOARCH=amd64 go build -o bin/darwin-amd64/bootcmd -ldflags $(LD_FLAGS) -a github.com/coreos/coreos-baremetal/cmd/bootcmd
+
+_output/coreos-baremetal-%.tar.gz: NAME=coreos-baremetal-$(VERSION)-$*
+_output/coreos-baremetal-%.tar.gz: DEST=_output/$(NAME)
+_output/coreos-baremetal-%.tar.gz: bin/%/bootcfg bin/%/bootcmd
 	mkdir -p $(DEST)
 	cp bin/$*/bootcfg $(DEST)
 	cp bin/$*/bootcmd $(DEST)

--- a/scripts/release-files
+++ b/scripts/release-files
@@ -24,7 +24,7 @@ cp examples/etc/bootcfg/openssl.conf $SCRIPTS/tls
 
 # systemd
 mkdir -p $CONTRIB/systemd
-cp contrib/systemd/bootcfg.service $CONTRIB/systemd
+cp -r contrib/systemd/* $CONTRIB/systemd
 
 # examples
 mkdir -p $DEST/examples


### PR DESCRIPTION
I've been playing with `bootcfg` on some ARM boards and other folks might like to do the same. Include it in the next release.

cc @crawford Makefile opinions?