### PR TITLE
examples: Add Kubernetes with rkt runtime (rktnetes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Guides and a service for network booting and provisioning CoreOS clusters on vir
 
 The [examples](examples) network boot and provision CoreOS clusters. Network boot [libvirt](scripts/README.md#libvirt) VMs to try the examples on your Linux laptop.
 
-* Multi-node [Kubernetes cluster](Documentation/kubernetes.md) with TLS
+* Multi-node [Kubernetes cluster](Documentation/kubernetes.md)
+* Multi-node Kubernetes cluster with rkt container runtime (i.e. rktnetes)
 * Multi-node [self-hosted Kubernetes cluster](Documentation/bootkube.md)
 * Multi-node etcd cluster
 * Multi-node [Torus](Documentation/torus.md) distributed storage cluster

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ These examples network boot and provision machines into CoreOS clusters using `b
 | etcd-install | Install a 3-node etcd cluster to disk | alpha/1109.1.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
 | k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
 | k8s-install | Install a Kubernetes cluster to disk | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (known bugs, experimental) | alpha/1122.0.0 | Disk | None |
 | bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | torus | Torus distributed storage | alpha/1109.1.0 | Disk | [tutorial](../Documentation/torus.md) |

--- a/examples/groups/rktnetes/node1.json
+++ b/examples/groups/rktnetes/node1.json
@@ -1,0 +1,19 @@
+{
+  "id": "node1",
+  "name": "k8s controller",
+  "profile": "rktnetes-controller",
+  "selector": {
+    "mac": "52:54:00:a1:9c:ae"
+  },
+  "metadata": {
+    "domain_name": "node1.example.com",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380",
+    "etcd_name": "node1",
+    "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
+    "k8s_dns_service_ip": "10.3.0.10",
+    "k8s_etcd_endpoints": "http://node1.example.com:2379",
+    "k8s_pod_network": "10.2.0.0/16",
+    "k8s_service_ip_range": "10.3.0.0/24",
+    "pxe": "true"
+  }
+}

--- a/examples/groups/rktnetes/node2.json
+++ b/examples/groups/rktnetes/node2.json
@@ -1,0 +1,17 @@
+{
+  "id": "node2",
+  "name": "k8s worker",
+  "profile": "rktnetes-worker",
+  "selector": {
+    "mac": "52:54:00:b2:2f:86"
+  },
+  "metadata": {
+    "domain_name": "node2.example.com",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380",
+    "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
+    "k8s_controller_endpoint": "https://node1.example.com",
+    "k8s_dns_service_ip": "10.3.0.10",
+    "k8s_etcd_endpoints": "http://node1.example.com:2379",
+    "pxe": "true"
+  }
+}

--- a/examples/groups/rktnetes/node3.json
+++ b/examples/groups/rktnetes/node3.json
@@ -1,0 +1,17 @@
+{
+  "id": "node3",
+  "name": "k8s worker",
+  "profile": "rktnetes-worker",
+  "selector": {
+    "mac": "52:54:00:c3:61:77"
+  },
+  "metadata": {
+    "domain_name": "node3.example.com",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380",
+    "k8s_cert_endpoint": "http://bootcfg.foo:8080/assets",
+    "k8s_controller_endpoint": "https://node1.example.com",
+    "k8s_dns_service_ip": "10.3.0.10",
+    "k8s_etcd_endpoints": "http://node1.example.com:2379",
+    "pxe": "true"
+  }
+}

--- a/examples/ignition/rktnetes-controller.yaml
+++ b/examples/ignition/rktnetes-controller.yaml
@@ -1,0 +1,792 @@
+---
+systemd:
+  units:
+    - name: etcd2.service
+      enable: true
+      dropins:
+        - name: 40-etcd-cluster.conf
+          contents: |
+            [Service]
+            Environment="ETCD_NAME={{.etcd_name}}"
+            Environment="ETCD_ADVERTISE_CLIENT_URLS=http://{{.domain_name}}:2379"
+            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.domain_name}}:2380"
+            Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379"
+            Environment="ETCD_LISTEN_PEER_URLS=http://{{.domain_name}}:2380"
+            Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
+            Environment="ETCD_STRICT_RECONFIG_CHECK=true"
+    - name: flanneld.service
+      dropins:
+        - name: 40-ExecStartPre-symlink.conf
+          contents: |
+            [Service]
+            EnvironmentFile=-/etc/flannel/options.env
+            ExecStartPre=/opt/init-flannel
+    - name: docker.service
+      dropins:
+        - name: 40-flannel.conf
+          contents: |
+            [Unit]
+            Requires=flanneld.service
+            After=flanneld.service
+            [Service]
+            ExecStart=
+            ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_MTU
+    - name: k8s-certs@.service
+      contents: |
+        [Unit]
+        Description=Fetch Kubernetes certificate assets
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ssl
+        ExecStart=/usr/bin/bash -c "[ -f /etc/kubernetes/ssl/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
+    - name: k8s-assets.target
+      contents: |
+        [Unit]
+        Description=Load Kubernetes Assets
+        Requires=k8s-certs@apiserver.pem.service
+        After=k8s-certs@apiserver.pem.service
+        Requires=k8s-certs@apiserver-key.pem.service
+        After=k8s-certs@apiserver-key.pem.service
+        Requires=k8s-certs@ca.pem.service
+        After=k8s-certs@ca.pem.service
+    - name: kubelet.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Kubelet via Hyperkube ACI
+        Wants=flanneld.service
+        Requires=k8s-assets.target
+        After=k8s-assets.target
+        [Service]
+        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+          --mount volume=dns,target=/etc/resolv.conf \
+          --volume=rkt,kind=host,source=/opt/bin/host-rkt \
+          --mount volume=rkt,target=/usr/bin/rkt \
+          --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
+          --mount volume=var-lib-rkt,target=/var/lib/rkt \
+          --volume=stage,kind=host,source=/tmp \
+          --mount volume=stage,target=/tmp"
+        Environment=KUBELET_VERSION=v1.3.4_coreos.0
+        ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+        ExecStartPre=/usr/bin/systemctl is-active flanneld.service
+        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+          --api-servers=http://127.0.0.1:8080 \
+          --register-schedulable=true \
+          --network-plugin-dir=/etc/kubernetes/cni/net.d \
+          --network-plugin=cni \
+          --container-runtime=rkt \
+          --rkt-path=/usr/bin/rkt \
+          --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
+          --allow-privileged=true \
+          --config=/etc/kubernetes/manifests \
+          --hostname-override={{.domain_name}} \
+          --cluster_dns={{.k8s_dns_service_ip}} \
+          --cluster_domain=cluster.local
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+    - name: k8s-addons.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Kubernetes Addons
+        [Service]
+        Type=oneshot
+        ExecStart=/opt/k8s-addons
+        [Install]
+        WantedBy=multi-user.target
+    - name: rkt-api.service
+      enable: true
+      contents: |
+        [Unit]
+        Before=kubelet.service
+        [Service]
+        ExecStart=/usr/bin/rkt api-service
+        Restart=always
+        RestartSec=10
+        [Install]
+        RequiredBy=kubelet.service
+    - name: load-rkt-stage1.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Load rkt stage1 images
+        Documentation=http://github.com/coreos/rkt
+        Requires=network-online.target
+        After=network-online.target
+        Before=rkt-api.service
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/bin/rkt fetch /usr/lib/rkt/stage1-images/stage1-coreos.aci /usr/lib/rkt/stage1-images/stage1-fly.aci  --insecure-options=image
+        [Install]
+        RequiredBy=rkt-api.service
+
+storage:
+  {{ if index . "pxe" }}
+  disks:
+    - device: /dev/sda
+      wipe_table: true
+      partitions:
+        - label: ROOT
+  filesystems:
+    - name: rootfs
+      mount:
+        device: "/dev/sda1"
+        format: "ext4"
+        create:
+          force: true
+          options:
+            - "-LROOT"
+  {{else}}
+  filesystems:
+    - name: rootfs
+      mount:
+        device: "/dev/disk/by-label/ROOT"
+        format: "ext4"
+  {{end}}
+  files:
+    - path: /etc/kubernetes/cni/net.d/10-flannel.conf
+      filesystem: rootfs
+      contents:
+        inline: |
+          {
+              "name": "podnet",
+              "type": "flannel",
+              "delegate": {
+                  "isDefaultGateway": true
+              }
+          }
+    - path: /etc/kubernetes/manifests/kube-proxy.yaml
+      filesystem: rootfs
+      contents:
+        inline: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: kube-proxy
+            namespace: kube-system
+            annotations:
+              rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
+          spec:
+            hostNetwork: true
+            containers:
+            - name: kube-proxy
+              image: quay.io/coreos/hyperkube:v1.3.4_coreos.0
+              command:
+              - /hyperkube
+              - proxy
+              - --master=http://127.0.0.1:8080
+              securityContext:
+                privileged: true
+              volumeMounts:
+              - mountPath: /etc/ssl/certs
+                name: ssl-certs-host
+                readOnly: true
+              - mountPath: /var/run/dbus
+                name: dbus
+                readOnly: false
+            volumes:
+            - hostPath:
+                path: /usr/share/ca-certificates
+              name: ssl-certs-host
+            - hostPath:
+                path: /var/run/dbus
+              name: dbus
+    - path: /etc/kubernetes/manifests/kube-apiserver.yaml
+      filesystem: rootfs
+      contents:
+        inline: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: kube-apiserver
+            namespace: kube-system
+          spec:
+            hostNetwork: true
+            containers:
+            - name: kube-apiserver
+              image: quay.io/coreos/hyperkube:v1.3.4_coreos.0
+              command:
+              - /hyperkube
+              - apiserver
+              - --bind-address=0.0.0.0
+              - --etcd-servers={{.k8s_etcd_endpoints}}
+              - --allow-privileged=true
+              - --service-cluster-ip-range={{.k8s_service_ip_range}}
+              - --secure-port=443
+              - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
+              - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
+              - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+              - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+              - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+              - --runtime-config=extensions/v1beta1/networkpolicies=true
+              livenessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  port: 8080
+                  path: /healthz
+                initialDelaySeconds: 15
+                timeoutSeconds: 15
+              ports:
+              - containerPort: 443
+                hostPort: 443
+                name: https
+              - containerPort: 8080
+                hostPort: 8080
+                name: local
+              volumeMounts:
+              - mountPath: /etc/kubernetes/ssl
+                name: ssl-certs-kubernetes
+                readOnly: true
+              - mountPath: /etc/ssl/certs
+                name: ssl-certs-host
+                readOnly: true
+            volumes:
+            - hostPath:
+                path: /etc/kubernetes/ssl
+              name: ssl-certs-kubernetes
+            - hostPath:
+                path: /usr/share/ca-certificates
+              name: ssl-certs-host
+    - path: /etc/flannel/options.env
+      filesystem: rootfs
+      contents:
+        inline: |
+          FLANNELD_ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
+    - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
+      filesystem: rootfs
+      contents:
+        inline: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: kube-controller-manager
+            namespace: kube-system
+          spec:
+            containers:
+            - name: kube-controller-manager
+              image: quay.io/coreos/hyperkube:v1.3.4_coreos.0
+              command:
+              - /hyperkube
+              - controller-manager
+              - --master=http://127.0.0.1:8080
+              - --leader-elect=true
+              - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+              - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+              resources:
+                requests:
+                  cpu: 200m
+              livenessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /healthz
+                  port: 10252
+                initialDelaySeconds: 15
+                timeoutSeconds: 15
+              volumeMounts:
+              - mountPath: /etc/kubernetes/ssl
+                name: ssl-certs-kubernetes
+                readOnly: true
+              - mountPath: /etc/ssl/certs
+                name: ssl-certs-host
+                readOnly: true
+            hostNetwork: true
+            volumes:
+            - hostPath:
+                path: /etc/kubernetes/ssl
+              name: ssl-certs-kubernetes
+            - hostPath:
+                path: /usr/share/ca-certificates
+              name: ssl-certs-host
+    - path: /etc/kubernetes/manifests/kube-scheduler.yaml
+      filesystem: rootfs
+      contents:
+        inline: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: kube-scheduler
+            namespace: kube-system
+          spec:
+            hostNetwork: true
+            containers:
+            - name: kube-scheduler
+              image: quay.io/coreos/hyperkube:v1.3.4_coreos.0
+              command:
+              - /hyperkube
+              - scheduler
+              - --master=http://127.0.0.1:8080
+              - --leader-elect=true
+              resources:
+                requests:
+                  cpu: 100m
+              livenessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /healthz
+                  port: 10251
+                initialDelaySeconds: 15
+                timeoutSeconds: 15
+    - path: /srv/kubernetes/manifests/kube-dns-rc.json
+      filesystem: rootfs
+      contents:
+        inline: |
+          {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+              "labels": {
+                "k8s-app": "kube-dns",
+                "kubernetes.io/cluster-service": "true",
+                "version": "v15"
+              },
+              "name": "kube-dns-v15",
+              "namespace": "kube-system"
+            },
+            "spec": {
+              "replicas": 1,
+              "selector": {
+                  "k8s-app": "kube-dns",
+                  "version": "v15"
+              },
+              "template": {
+                "metadata": {
+                  "labels": {
+                    "k8s-app": "kube-dns",
+                    "kubernetes.io/cluster-service": "true",
+                    "version": "v15"
+                  }
+                },
+                "spec": {
+                  "containers": [
+                      {
+                        "args": [
+                          "--domain=cluster.local.",
+                          "--dns-port=10053"
+                        ],
+                        "image": "gcr.io/google_containers/kubedns-amd64:1.3",
+                        "livenessProbe": {
+                          "failureThreshold": 5,
+                          "httpGet": {
+                            "path": "/healthz",
+                            "port": 8080,
+                            "scheme": "HTTP"
+                          },
+                          "initialDelaySeconds": 60,
+                          "successThreshold": 1,
+                          "timeoutSeconds": 5
+                        },
+                        "name": "kubedns",
+                        "ports": [
+                          {
+                            "containerPort": 10053,
+                            "name": "dns-local",
+                            "protocol": "UDP"
+                          },
+                          {
+                            "containerPort": 10053,
+                            "name": "dns-tcp-local",
+                            "protocol": "TCP"
+                          }
+                        ],
+                        "readinessProbe": {
+                          "httpGet": {
+                            "path": "/readiness",
+                            "port": 8081,
+                            "scheme": "HTTP"
+                          },
+                          "initialDelaySeconds": 30,
+                          "timeoutSeconds": 5
+                        },
+                        "resources": {
+                          "limits": {
+                            "cpu": "100m",
+                            "memory": "200Mi"
+                          },
+                          "requests": {
+                            "cpu": "100m",
+                            "memory": "50Mi"
+                          }
+                        }
+                      },
+                      {
+                        "args": [
+                          "--cache-size=1000",
+                          "--no-resolv",
+                          "--server=127.0.0.1#10053"
+                        ],
+                        "image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.3",
+                        "name": "dnsmasq",
+                        "ports": [
+                          {
+                            "containerPort": 53,
+                            "name": "dns",
+                            "protocol": "UDP"
+                          },
+                          {
+                            "containerPort": 53,
+                            "name": "dns-tcp",
+                            "protocol": "TCP"
+                          }
+                        ]
+                      },
+                      {
+                        "args": [
+                          "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
+                          "-port=8080",
+                          "-quiet"
+                        ],
+                        "image": "gcr.io/google_containers/exechealthz-amd64:1.0",
+                        "name": "healthz",
+                        "ports": [
+                          {
+                            "containerPort": 8080,
+                            "protocol": "TCP"
+                          }
+                        ],
+                        "resources": {
+                          "limits": {
+                            "cpu": "10m",
+                            "memory": "20Mi"
+                          },
+                          "requests": {
+                            "cpu": "10m",
+                            "memory": "20Mi"
+                          }
+                        }
+                      }
+                  ],
+                  "dnsPolicy": "Default"
+                }
+              }
+            }
+          }
+    - path: /srv/kubernetes/manifests/kube-dns-svc.json
+      filesystem: rootfs
+      contents:
+        inline: |
+          {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+              "labels": {
+                "k8s-app": "kube-dns",
+                "kubernetes.io/cluster-service": "true",
+                "kubernetes.io/name": "KubeDNS"
+              },
+              "name": "kube-dns",
+              "namespace": "kube-system"
+            },
+            "spec": {
+              "clusterIP": "{{.k8s_dns_service_ip}}",
+              "ports": [
+                {
+                  "name": "dns",
+                  "port": 53,
+                  "protocol": "UDP"
+                },
+                {
+                  "name": "dns-tcp",
+                  "port": 53,
+                  "protocol": "TCP"
+                }
+              ],
+              "selector": {
+                "k8s-app": "kube-dns"
+              }
+            }
+          }
+    - path: /srv/kubernetes/manifests/heapster-deployment.json
+      filesystem: rootfs
+      contents:
+        inline: |
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "Deployment",
+            "metadata": {
+              "labels": {
+                "k8s-app": "heapster",
+                "kubernetes.io/cluster-service": "true",
+                "version": "v1.1.0"
+              },
+              "name": "heapster-v1.1.0",
+              "namespace": "kube-system"
+            },
+            "spec": {
+              "replicas": 1,
+              "selector": {
+                "matchLabels": {
+                  "k8s-app": "heapster",
+                  "version": "v1.1.0"
+                }
+              },
+              "template": {
+                "metadata": {
+                  "labels": {
+                    "k8s-app": "heapster",
+                    "version": "v1.1.0"
+                  }
+                },
+                "spec": {
+                  "containers": [
+                    {
+                      "command": [
+                        "/heapster",
+                        "--source=kubernetes.summary_api:''"
+                      ],
+                      "image": "gcr.io/google_containers/heapster:v1.1.0",
+                      "name": "heapster",
+                      "resources": {
+                        "limits": {
+                          "cpu": "100m",
+                          "memory": "200Mi"
+                        },
+                        "requests": {
+                          "cpu": "100m",
+                          "memory": "200Mi"
+                        }
+                      }
+                    },
+                    {
+                      "command": [
+                        "/pod_nanny",
+                        "--cpu=100m",
+                        "--extra-cpu=0.5m",
+                        "--memory=200Mi",
+                        "--extra-memory=4Mi",
+                        "--threshold=5",
+                        "--deployment=heapster-v1.1.0",
+                        "--container=heapster",
+                        "--poll-period=300000",
+                        "--estimator=exponential"
+                      ],
+                      "env": [
+                        {
+                          "name": "MY_POD_NAME",
+                          "valueFrom": {
+                            "fieldRef": {
+                              "fieldPath": "metadata.name"
+                            }
+                          }
+                        },
+                        {
+                          "name": "MY_POD_NAMESPACE",
+                          "valueFrom": {
+                            "fieldRef": {
+                              "fieldPath": "metadata.namespace"
+                            }
+                          }
+                        }
+                      ],
+                      "image": "gcr.io/google_containers/addon-resizer:1.3",
+                      "name": "heapster-nanny",
+                      "resources": {
+                        "limits": {
+                          "cpu": "50m",
+                          "memory": "100Mi"
+                        },
+                        "requests": {
+                          "cpu": "50m",
+                          "memory": "100Mi"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+    - path: /srv/kubernetes/manifests/heapster-svc.json
+      filesystem: rootfs
+      contents:
+        inline: |
+          {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+              "labels": {
+                "kubernetes.io/cluster-service": "true",
+                "kubernetes.io/name": "Heapster"
+              },
+              "name": "heapster",
+              "namespace": "kube-system"
+            },
+            "spec": {
+              "ports": [
+                {
+                  "port": 80,
+                  "targetPort": 8082
+                }
+              ],
+              "selector": {
+                "k8s-app": "heapster"
+              }
+            }
+          }
+    - path: /srv/kubernetes/manifests/kube-dashboard-rc.json
+      filesystem: rootfs
+      contents:
+        inline: |
+          {
+            "apiVersion": "v1",
+            "kind": "ReplicationController",
+            "metadata": {
+              "labels": {
+                "k8s-app": "kubernetes-dashboard",
+                "kubernetes.io/cluster-service": "true",
+                "version": "v1.1.0"
+              },
+              "name": "kubernetes-dashboard-v1.1.0",
+              "namespace": "kube-system"
+            },
+            "spec": {
+              "replicas": 1,
+              "selector": {
+                "k8s-app": "kubernetes-dashboard"
+              },
+              "template": {
+                "metadata": {
+                  "labels": {
+                    "k8s-app": "kubernetes-dashboard",
+                    "kubernetes.io/cluster-service": "true",
+                    "version": "v1.1.0"
+                  }
+                },
+                "spec": {
+                  "containers": [
+                    {
+                      "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0",
+                      "livenessProbe": {
+                        "httpGet": {
+                          "path": "/",
+                          "port": 9090
+                        },
+                        "initialDelaySeconds": 30,
+                        "timeoutSeconds": 30
+                      },
+                      "name": "kubernetes-dashboard",
+                      "ports": [
+                        {
+                          "containerPort": 9090
+                        }
+                      ],
+                      "resources": {
+                        "limits": {
+                          "cpu": "100m",
+                          "memory": "50Mi"
+                        },
+                        "requests": {
+                          "cpu": "100m",
+                          "memory": "50Mi"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+    - path: /srv/kubernetes/manifests/kube-dashboard-svc.json
+      filesystem: rootfs
+      contents:
+        inline: |
+          {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+              "labels": {
+                "k8s-app": "kubernetes-dashboard",
+                "kubernetes.io/cluster-service": "true"
+              },
+              "name": "kubernetes-dashboard",
+              "namespace": "kube-system"
+            },
+            "spec": {
+              "ports": [
+                {
+                  "port": 80,
+                  "targetPort": 9090
+                }
+              ],
+              "selector": {
+                "k8s-app": "kubernetes-dashboard"
+              }
+            }
+          }
+    - path: /opt/init-flannel
+      filesystem: rootfs
+      mode: 0544
+      contents:
+        inline: |
+          #!/bin/bash -ex
+          function init_flannel {
+            echo "Waiting for etcd..."
+            while true
+            do
+                IFS=',' read -ra ES <<< "{{.k8s_etcd_endpoints}}"
+                for ETCD in "${ES[@]}"; do
+                    echo "Trying: $ETCD"
+                    if [ -n "$(curl --silent "$ETCD/v2/machines")" ]; then
+                        local ACTIVE_ETCD=$ETCD
+                        break
+                    fi
+                    sleep 1
+                done
+                if [ -n "$ACTIVE_ETCD" ]; then
+                    break
+                fi
+            done
+            RES=$(curl --silent -X PUT -d "value={\"Network\":\"{{.k8s_pod_network}}\",\"Backend\":{\"Type\":\"vxlan\"}}" "$ACTIVE_ETCD/v2/keys/coreos.com/network/config?prevExist=false")
+            if [ -z "$(echo $RES | grep '"action":"create"')" ] && [ -z "$(echo $RES | grep 'Key already exists')" ]; then
+                echo "Unexpected error configuring flannel pod network: $RES"
+            fi
+          }
+          init_flannel
+    - path: /opt/bin/host-rkt
+      filesystem: rootfs
+      mode: 0544
+      contents:
+        inline: |
+          #!/bin/sh
+          # This is bind mounted into the kubelet rootfs and all rkt shell-outs go
+          # through this rkt wrapper. It essentially enters the host mount namespace
+          # (which it is already in) only for the purpose of breaking out of the chroot
+          # before calling rkt. It makes things like rkt gc work and avoids bind mounting
+          # in certain rkt filesystem dependancies into the kubelet rootfs. This can
+          # eventually be obviated when the write-api stuff gets upstream and rkt gc is
+          # through the api-server. Related issue:
+          # https://github.com/coreos/rkt/issues/2878
+          exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
+    - path: /opt/k8s-addons
+      filesystem: rootfs
+      mode: 0544
+      contents:
+        inline: |
+          #!/bin/bash -ex
+          echo "Waiting for Kubernetes API..."
+          until curl --silent "http://127.0.0.1:8080/version"
+          do
+            sleep 5
+          done
+          echo "K8S: DNS addon"
+          curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+          curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+          echo "K8S: Heapster addon"
+          curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-deployment.json)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
+          curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
+          echo "K8S: Dashboard addon"
+          curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-rc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
+          curl --silent -H "Content-Type: application/json" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-svc.json)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
+
+{{ if index . "ssh_authorized_keys" }}
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        {{ range $element := .ssh_authorized_keys }}
+        - {{$element}}
+        {{end}}
+{{end}}

--- a/examples/ignition/rktnetes-worker.yaml
+++ b/examples/ignition/rktnetes-worker.yaml
@@ -1,0 +1,246 @@
+---
+systemd:
+  units:
+    - name: etcd2.service
+      enable: true
+      dropins:
+        - name: 40-etcd-cluster.conf
+          contents: |
+            [Service]
+            Environment="ETCD_PROXY=on"
+            Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379"
+            Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
+    - name: flanneld.service
+      dropins:
+        - name: 40-add-options.conf
+          contents: |
+            [Service]
+            EnvironmentFile=-/etc/flannel/options.env
+    - name: docker.service
+      dropins:
+        - name: 40-flannel.conf
+          contents: |
+            [Unit]
+            Requires=flanneld.service
+            After=flanneld.service
+            [Service]
+            ExecStart=
+            ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_MTU
+    - name: k8s-certs@.service
+      contents: |
+        [Unit]
+        Description=Fetch Kubernetes certificate assets
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/ssl
+        ExecStart=/usr/bin/bash -c "[ -f /etc/kubernetes/ssl/%i ] || curl {{.k8s_cert_endpoint}}/tls/%i -o /etc/kubernetes/ssl/%i"
+    - name: k8s-assets.target
+      contents: |
+        [Unit]
+        Description=Load Kubernetes Assets
+        Requires=k8s-certs@worker.pem.service
+        After=k8s-certs@worker.pem.service
+        Requires=k8s-certs@worker-key.pem.service
+        After=k8s-certs@worker-key.pem.service
+        Requires=k8s-certs@ca.pem.service
+        After=k8s-certs@ca.pem.service
+    - name: kubelet.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Kubelet via Hyperkube ACI
+        Requires=k8s-assets.target
+        After=k8s-assets.target
+        [Service]
+        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+            --mount volume=dns,target=/etc/resolv.conf \
+            --volume=rkt,kind=host,source=/opt/bin/host-rkt \
+            --mount volume=rkt,target=/usr/bin/rkt \
+            --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
+            --mount volume=var-lib-rkt,target=/var/lib/rkt \
+            --volume=stage,kind=host,source=/tmp \
+            --mount volume=stage,target=/tmp"
+        Environment=KUBELET_VERSION=v1.3.4_coreos.0
+        ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+          --api-servers={{.k8s_controller_endpoint}} \
+          --network-plugin-dir=/etc/kubernetes/cni/net.d \
+          --network-plugin=cni \
+          --container-runtime=rkt \
+          --rkt-path=/usr/bin/rkt \
+          --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
+          --register-node=true \
+          --allow-privileged=true \
+          --config=/etc/kubernetes/manifests \
+          --hostname-override={{.domain_name}} \
+          --cluster_dns={{.k8s_dns_service_ip}} \
+          --cluster_domain=cluster.local \
+          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+          --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
+          --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+    - name: rkt-api.service
+      enable: true
+      contents: |
+        [Unit]
+        Before=kubelet.service
+        [Service]
+        ExecStart=/usr/bin/rkt api-service
+        Restart=always
+        RestartSec=10
+        [Install]
+        RequiredBy=kubelet.service
+    - name: load-rkt-stage1.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Load rkt stage1 images
+        Documentation=http://github.com/coreos/rkt
+        Requires=network-online.target
+        After=network-online.target
+        Before=rkt-api.service
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/bin/rkt fetch /usr/lib/rkt/stage1-images/stage1-coreos.aci /usr/lib/rkt/stage1-images/stage1-fly.aci  --insecure-options=image
+        [Install]
+        RequiredBy=rkt-api.service
+
+storage:
+  {{ if index . "pxe" }}
+  disks:
+    - device: /dev/sda
+      wipe_table: true
+      partitions:
+        - label: ROOT
+  filesystems:
+    - name: rootfs
+      mount:
+        device: "/dev/sda1"
+        format: "ext4"
+        create:
+          force: true
+          options:
+            - "-LROOT"
+  {{else}}
+  filesystems:
+    - name: rootfs
+      mount:
+        device: "/dev/disk/by-label/ROOT"
+        format: "ext4"
+  {{end}}
+  files:
+    - path: /etc/kubernetes/cni/net.d/10-flannel.conf
+      filesystem: rootfs
+      contents:
+        inline: |
+          {
+              "name": "podnet",
+              "type": "flannel",
+              "delegate": {
+                  "isDefaultGateway": true
+              }
+          }
+    - path: /etc/kubernetes/worker-kubeconfig.yaml
+      filesystem: rootfs
+      contents:
+        inline: |
+          apiVersion: v1
+          kind: Config
+          clusters:
+          - name: local
+            cluster:
+              certificate-authority: /etc/kubernetes/ssl/ca.pem
+          users:
+          - name: kubelet
+            user:
+              client-certificate: /etc/kubernetes/ssl/worker.pem
+              client-key: /etc/kubernetes/ssl/worker-key.pem
+          contexts:
+          - context:
+              cluster: local
+              user: kubelet
+            name: kubelet-context
+          current-context: kubelet-context
+    - path: /etc/kubernetes/manifests/kube-proxy.yaml
+      filesystem: rootfs
+      contents:
+        inline: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: kube-proxy
+            namespace: kube-system
+            annotations:
+              rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
+          spec:
+            hostNetwork: true
+            containers:
+            - name: kube-proxy
+              image: quay.io/coreos/hyperkube:v1.3.4_coreos.0
+              command:
+              - /hyperkube
+              - proxy
+              - --master={{.k8s_controller_endpoint}}
+              - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - mountPath: /etc/ssl/certs
+                  name: "ssl-certs"
+                - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
+                  name: "kubeconfig"
+                  readOnly: true
+                - mountPath: /etc/kubernetes/ssl
+                  name: "etc-kube-ssl"
+                  readOnly: true
+                - mountPath: /var/run/dbus
+                  name: dbus
+                  readOnly: false
+            volumes:
+              - name: "ssl-certs"
+                hostPath:
+                  path: "/usr/share/ca-certificates"
+              - name: "kubeconfig"
+                hostPath:
+                  path: "/etc/kubernetes/worker-kubeconfig.yaml"
+              - name: "etc-kube-ssl"
+                hostPath:
+                  path: "/etc/kubernetes/ssl"
+              - hostPath:
+                  path: /var/run/dbus
+                name: dbus
+    - path: /etc/flannel/options.env
+      filesystem: rootfs
+      contents:
+        inline: |
+          FLANNELD_ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
+    - path: /opt/bin/host-rkt
+      filesystem: rootfs
+      mode: 0544
+      contents:
+        inline: |
+          #!/bin/sh
+          # This is bind mounted into the kubelet rootfs and all rkt shell-outs go
+          # through this rkt wrapper. It essentially enters the host mount namespace
+          # (which it is already in) only for the purpose of breaking out of the chroot
+          # before calling rkt. It makes things like rkt gc work and avoids bind mounting
+          # in certain rkt filesystem dependancies into the kubelet rootfs. This can
+          # eventually be obviated when the write-api stuff gets upstream and rkt gc is
+          # through the api-server. Related issue:
+          # https://github.com/coreos/rkt/issues/2878
+          exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
+
+{{ if index . "ssh_authorized_keys" }}
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        {{ range $element := .ssh_authorized_keys }}
+        - {{$element}}
+        {{end}}
+{{end}}

--- a/examples/profiles/rktnetes-controller.json
+++ b/examples/profiles/rktnetes-controller.json
@@ -1,0 +1,16 @@
+{
+  "id": "rktnetes-controller",
+  "name": "Kubernetes Controller",
+  "boot": {
+    "kernel": "/assets/coreos/1122.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1122.0.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "root": "/dev/sda1",
+      "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": "",
+      "coreos.first_boot": ""
+    }
+  },
+  "cloud_id": "",
+  "ignition_id": "rktnetes-controller.yaml"
+}

--- a/examples/profiles/rktnetes-worker.json
+++ b/examples/profiles/rktnetes-worker.json
@@ -1,0 +1,16 @@
+{
+  "id": "rktnetes-worker",
+  "name": "Kubernetes Worker",
+  "boot": {
+    "kernel": "/assets/coreos/1122.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1122.0.0/coreos_production_pxe_image.cpio.gz"],
+    "cmdline": {
+      "root": "/dev/sda1",
+      "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.autologin": "",
+      "coreos.first_boot": ""
+    }
+  },
+  "cloud_id": "",
+  "ignition_id": "rktnetes-worker.yaml"
+}


### PR DESCRIPTION
* Add an example Kubernetes cluster with rkt as the container runtime, CoreOS 1122.0.0, and rkt 1.11.0 (i.e. rktnetes).
* Ports over the great work by rkt folks https://github.com/coreos/coreos-kubernetes/pull/551 and @pbx0 

Don't merge yet.

```
NAME                STATUS    AGE
node1.example.com   Ready     10m
node2.example.com   Ready     10m
node3.example.com   Ready     11m
```

All pods.

```
NAMESPACE     NAME                                        READY     STATUS    RESTARTS   AGE
kube-system   heapster-v1.1.0-3647315203-gcl2w            2/2       Running   0          11m
kube-system   kube-apiserver-node1.example.com            1/1       Running   0          12m
kube-system   kube-controller-manager-node1.example.com   1/1       Running   0          12m
kube-system   kube-dns-v15-beool                          3/3       Running   0          12m
kube-system   kube-proxy-node1.example.com                1/1       Running   0          12m
kube-system   kube-proxy-node2.example.com                1/1       Running   0          12m
kube-system   kube-proxy-node3.example.com                1/1       Running   0          11m
kube-system   kube-scheduler-node1.example.com            1/1       Running   0          12m
kube-system   kubernetes-dashboard-v1.1.0-zl083           1/1       Running   0          12m
```

Controller pod list.

```
$ rkt list
UUID		APP			IMAGE NAME							STATE	CREATED		STARTED		NETWORKS
05ff6991	flannel			quay.io/coreos/flannel:0.5.5					running	14 minutes ago	14 minutes ago	
16185061	flannel			quay.io/coreos/flannel:0.5.5					exited	14 minutes ago	14 minutes ago	
32a854a6	kube-scheduler		quay.io/coreos/hyperkube:v1.3.4_coreos.0			running	11 minutes ago	11 minutes ago	
5e61b9e7	kube-controller-manager	quay.io/coreos/hyperkube:v1.3.4_coreos.0			running	11 minutes ago	11 minutes ago	
78f904a5	kube-apiserver		quay.io/coreos/hyperkube:v1.3.4_coreos.0			running	11 minutes ago	11 minutes ago	
a268d03a	kubedns			gcr.io/google_containers/kubedns-amd64:1.3			running	10 minutes ago	10 minutes ago	
		dnsmasq			gcr.io/google_containers/kube-dnsmasq-amd64:1.3			
		healthz			gcr.io/google_containers/exechealthz-amd64:1.0			
b2a2f47d	hyperkube		quay.io/coreos/hyperkube:v1.3.4_coreos.0			running	11 minutes ago	11 minutes ago	
cfd1c2b8	kubernetes-dashboard	gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0	running	11 minutes ago	11 minutes ago	
d5372916	kube-proxy		quay.io/coreos/hyperkube:v1.3.4_coreos.0			running	11 minutes ago	11 minutes ago
```


