### PR TITLE
examples: Update self-hosted Kubernetes to v1.3.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,9 @@
 
 #### Examples
 
+* Add Kubernetes with rkt container runtime (i.e. rktnetes)
 * Upgrade Kubernetes v1.3.4 (static manifest) example clusters
-* Upgrade Kubernetes v1.3.0 (self-hosted) example cluster
+* Upgrade Kubernetes v1.3.4 (self-hosted) example cluster
 * Use DNS names (instead of IPs) in example clusters (except bootkube)
 
 ## v0.4.0 (2016-07-21)

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,7 +1,7 @@
 
 # Self-Hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node Kubernetes v1.3.0 cluster with etcd, flannel, and a special "runonce" host Kublet. The CoreOS [bootkube](https://github.com/coreos/bootkube) tool is used to bootstrap kubelet, apiserver, scheduler, and controller-manager as pods, which can be managed via kubectl. `bootkube start` is run on any controller (master) to create a temporary control-plane and start Kubernetes components initially. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node Kubernetes v1.3.4 cluster with etcd, flannel, and a special "runonce" host Kublet. The CoreOS [bootkube](https://github.com/coreos/bootkube) tool is used to bootstrap kubelet, apiserver, scheduler, and controller-manager as pods, which can be managed via kubectl. `bootkube start` is run on any controller (master) to create a temporary control-plane and start Kubernetes components initially. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Experimental
 
@@ -15,7 +15,7 @@ Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) g
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
 
-Build and install [bootkube](https://github.com/coreos/bootkube/releases) v0.1.2.
+Build and install [bootkube](https://github.com/coreos/bootkube/releases) v0.1.4.
 
 ## Examples
 

--- a/examples/groups/bootkube-install/node1.json
+++ b/examples/groups/bootkube-install/node1.json
@@ -1,7 +1,7 @@
 {
   "id": "node1",
-  "name": "Master Node",
-  "profile": "bootkube-master",
+  "name": "Controller Node",
+  "profile": "bootkube-controller",
   "selector": {
     "mac": "52:54:00:a1:9c:ae",
     "os": "installed"

--- a/examples/groups/bootkube/node1.json
+++ b/examples/groups/bootkube/node1.json
@@ -1,7 +1,7 @@
 {
   "id": "node1",
-  "name": "Master Node",
-  "profile": "bootkube-master",
+  "name": "Controller Node",
+  "profile": "bootkube-controller",
   "selector": {
     "mac": "52:54:00:a1:9c:ae"
   },

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -46,7 +46,7 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.3.0_coreos.1
+        Environment=KUBELET_VERSION=v1.3.4_coreos.0
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
@@ -111,7 +111,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.1.2}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.1.4}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/home/core/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -41,7 +41,7 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.3.0_coreos.1
+        Environment=KUBELET_VERSION=v1.3.4_coreos.0
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -1,6 +1,6 @@
 {
-  "id": "bootkube-master",
-  "name": "bootkube Ready Master",
+  "id": "bootkube-controller",
+  "name": "bootkube Ready Controller",
   "boot": {
     "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
@@ -12,5 +12,5 @@
     }
   },
   "cloud_id": "",
-  "ignition_id": "bootkube-master.yaml"
+  "ignition_id": "bootkube-controller.yaml"
 }


### PR DESCRIPTION
* Use bootkube v0.1.4 for self-hosted bootstrapping