### PR TITLE
examples: Bump k8s and k8s-install to CoreOS 1122.0.0

### DIFF
--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -23,7 +23,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
+    ./scripts/get-coreos alpha 1122.0.0 ./examples/assets
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,8 +11,8 @@ These examples network boot and provision machines into CoreOS clusters using `b
 | etcd | iPXE boot a 3 node etcd cluster and proxy | alpha/1109.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
 | etcd-install | Install a 3-node etcd cluster to disk | alpha/1109.1.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
 | etcd3 | Install a 3-node etcd3 cluster | alpha/1109.1.0 | RAM | None |
-| k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| k8s-install | Install a Kubernetes cluster to disk | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1122.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| k8s-install | Install a Kubernetes cluster to disk | alpha/1122.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
 | rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (known bugs, experimental) | alpha/1122.0.0 | Disk | None |
 | bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |

--- a/examples/profiles/k8s-master-install.json
+++ b/examples/profiles/k8s-master-install.json
@@ -2,8 +2,8 @@
   "id": "k8s-master-install",
   "name": "Kubernetes Master Install",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1122.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1122.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-master.json
+++ b/examples/profiles/k8s-master.json
@@ -2,8 +2,8 @@
   "id": "k8s-master",
   "name": "Kubernetes Master",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1122.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1122.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/k8s-worker-install.json
+++ b/examples/profiles/k8s-worker-install.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker-install",
   "name": "Kubernetes Worker Install",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1122.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1122.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-worker.json
+++ b/examples/profiles/k8s-worker.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1122.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1122.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",


### PR DESCRIPTION
cc @Titerote @mischief from IRC discussion.

Following the qemu/kvm PXE boot [tutorial](https://github.com/coreos/coreos-baremetal/blob/1f5c7a6d5a6ddb2fa1416f964d16a852289d069b/Documentation/kubernetes.md) for `k8s` on CoreOS 1122.0.0.

```
$ kubectl --kubeconfig=examples/assets/tls/kubeconfig describe nodes
Name:			node1.example.com
Labels:			beta.kubernetes.io/arch=amd64
			beta.kubernetes.io/os=linux
			kubernetes.io/hostname=node1.example.com
Taints:			<none>
CreationTimestamp:	Sun, 21 Aug 2016 17:15:17 -0700
Phase:			
Conditions:
  Type			Status	LastHeartbeatTime			LastTransitionTime			Reason				Message
  ----			------	-----------------			------------------			------				-------
  OutOfDisk 		False 	Sun, 21 Aug 2016 17:17:47 -0700 	Sun, 21 Aug 2016 17:15:17 -0700 	KubeletHasSufficientDisk 	kubelet has sufficient disk space available
  MemoryPressure 	False 	Sun, 21 Aug 2016 17:17:47 -0700 	Sun, 21 Aug 2016 17:15:17 -0700 	KubeletHasSufficientMemory 	kubelet has sufficient memory available
  Ready 		True 	Sun, 21 Aug 2016 17:17:47 -0700 	Sun, 21 Aug 2016 17:15:17 -0700 	KubeletReady 			kubelet is posting ready status
Addresses:		172.15.0.21,172.15.0.21
Capacity:
 alpha.kubernetes.io/nvidia-gpu:	0
 cpu:					1
 memory:				1020980Ki
 pods:					110
Allocatable:
 alpha.kubernetes.io/nvidia-gpu:	0
 cpu:					1
 memory:				1020980Ki
 pods:					110
System Info:
 Machine ID:			748cfc5d0ac0444e85d1cccb08411403
 System UUID:			93E58FF7-D06D-444A-BEB2-624F1121AB81
 Boot ID:			f60cca30-5eb4-47b9-84e9-c2cb8ed15502
 Kernel Version:		4.7.0-coreos
 OS Image:			CoreOS 1122.0.0 (MoreOS)
 Operating System:		linux
 Architecture:			amd64
 Container Runtime Version:	docker://1.11.2
 Kubelet Version:		v1.3.4+coreos.0
 Kube-Proxy Version:		v1.3.4+coreos.0
ExternalID:			node1.example.com
Non-terminated Pods:		(4 in total)
  Namespace			Name							CPU Requests	CPU Limits	Memory Requests	Memory Limits
  ---------			----							------------	----------	---------------	-------------
  kube-system			kube-apiserver-node1.example.com			0 (0%)		0 (0%)		0 (0%)		0 (0%)
  kube-system			kube-controller-manager-node1.example.com		200m (20%)	0 (0%)		0 (0%)		0 (0%)
  kube-system			kube-proxy-node1.example.com				0 (0%)		0 (0%)		0 (0%)		0 (0%)
  kube-system			kube-scheduler-node1.example.com			100m (10%)	0 (0%)		0 (0%)		0 (0%)
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted. More info: http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md)
  CPU Requests	CPU Limits	Memory Requests	Memory Limits
  ------------	----------	---------------	-------------
  300m (30%)	0 (0%)		0 (0%)		0 (0%)
Events:
  FirstSeen	LastSeen	Count	From				SubobjectPath	Type		Reason			Message
  ---------	--------	-----	----				-------------	--------	------			-------
  4m		4m		1	{kubelet node1.example.com}			Normal		Starting		Starting kubelet.
  4m		2m		46	{kubelet node1.example.com}			Normal		NodeHasSufficientDisk	Node node1.example.com status is now: NodeHasSufficientDisk
  4m		2m		46	{kubelet node1.example.com}			Normal		NodeHasSufficientMemory	Node node1.example.com status is now: NodeHasSufficientMemory
  2m		2m		1	{controllermanager }				Normal		RegisteredNode		Node node1.example.com event: Registered Node node1.example.com in NodeController


Name:			node2.example.com
Labels:			beta.kubernetes.io/arch=amd64
			beta.kubernetes.io/os=linux
			kubernetes.io/hostname=node2.example.com
Taints:			<none>
CreationTimestamp:	Sun, 21 Aug 2016 17:15:16 -0700
Phase:			
Conditions:
  Type			Status	LastHeartbeatTime			LastTransitionTime			Reason				Message
  ----			------	-----------------			------------------			------				-------
  OutOfDisk 		False 	Sun, 21 Aug 2016 17:17:47 -0700 	Sun, 21 Aug 2016 17:15:16 -0700 	KubeletHasSufficientDisk 	kubelet has sufficient disk space available
  MemoryPressure 	False 	Sun, 21 Aug 2016 17:17:47 -0700 	Sun, 21 Aug 2016 17:15:16 -0700 	KubeletHasSufficientMemory 	kubelet has sufficient memory available
  Ready 		True 	Sun, 21 Aug 2016 17:17:47 -0700 	Sun, 21 Aug 2016 17:15:16 -0700 	KubeletReady 			kubelet is posting ready status
Addresses:		172.15.0.22,172.15.0.22
Capacity:
 alpha.kubernetes.io/nvidia-gpu:	0
 cpu:					1
 memory:				1020980Ki
 pods:					110
Allocatable:
 alpha.kubernetes.io/nvidia-gpu:	0
 cpu:					1
 memory:				1020980Ki
 pods:					110
System Info:
 Machine ID:			748cfc5d0ac0444e85d1cccb08411403
 System UUID:			47F9FEB4-A6B0-4B55-A65F-0438CEAF65EB
 Boot ID:			81184187-f2c0-46a5-ba22-099ed43cc321
 Kernel Version:		4.7.0-coreos
 OS Image:			CoreOS 1122.0.0 (MoreOS)
 Operating System:		linux
 Architecture:			amd64
 Container Runtime Version:	docker://1.11.2
 Kubelet Version:		v1.3.4+coreos.0
 Kube-Proxy Version:		v1.3.4+coreos.0
ExternalID:			node2.example.com
Non-terminated Pods:		(2 in total)
  Namespace			Name					CPU Requests	CPU Limits	Memory Requests	Memory Limits
  ---------			----					------------	----------	---------------	-------------
  kube-system			kube-dns-v15-q79ap			110m (11%)	110m (11%)	70Mi (7%)	220Mi (22%)
  kube-system			kube-proxy-node2.example.com		0 (0%)		0 (0%)		0 (0%)		0 (0%)
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted. More info: http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md)
  CPU Requests	CPU Limits	Memory Requests	Memory Limits
  ------------	----------	---------------	-------------
  110m (11%)	110m (11%)	70Mi (7%)	220Mi (22%)
Events:
  FirstSeen	LastSeen	Count	From				SubobjectPath	Type		Reason			Message
  ---------	--------	-----	----				-------------	--------	------			-------
  4m		4m		1	{kubelet node2.example.com}			Normal		Starting		Starting kubelet.
  4m		2m		25	{kubelet node2.example.com}			Normal		NodeHasSufficientDisk	Node node2.example.com status is now: NodeHasSufficientDisk
  4m		2m		25	{kubelet node2.example.com}			Normal		NodeHasSufficientMemory	Node node2.example.com status is now: NodeHasSufficientMemory
  2m		2m		1	{controllermanager }				Normal		RegisteredNode		Node node2.example.com event: Registered Node node2.example.com in NodeController


Name:			node3.example.com
Labels:			beta.kubernetes.io/arch=amd64
			beta.kubernetes.io/os=linux
			kubernetes.io/hostname=node3.example.com
Taints:			<none>
CreationTimestamp:	Sun, 21 Aug 2016 17:15:17 -0700
Phase:			
Conditions:
  Type			Status	LastHeartbeatTime			LastTransitionTime			Reason				Message
  ----			------	-----------------			------------------			------				-------
  OutOfDisk 		False 	Sun, 21 Aug 2016 17:17:48 -0700 	Sun, 21 Aug 2016 17:15:17 -0700 	KubeletHasSufficientDisk 	kubelet has sufficient disk space available
  MemoryPressure 	False 	Sun, 21 Aug 2016 17:17:48 -0700 	Sun, 21 Aug 2016 17:15:17 -0700 	KubeletHasSufficientMemory 	kubelet has sufficient memory available
  Ready 		True 	Sun, 21 Aug 2016 17:17:48 -0700 	Sun, 21 Aug 2016 17:15:17 -0700 	KubeletReady 			kubelet is posting ready status
Addresses:		172.15.0.23,172.15.0.23
Capacity:
 alpha.kubernetes.io/nvidia-gpu:	0
 cpu:					1
 memory:				1020980Ki
 pods:					110
Allocatable:
 alpha.kubernetes.io/nvidia-gpu:	0
 cpu:					1
 memory:				1020980Ki
 pods:					110
System Info:
 Machine ID:			748cfc5d0ac0444e85d1cccb08411403
 System UUID:			C973F03F-CC5D-4E8F-9281-BFB8239E7BFC
 Boot ID:			40fc9149-4171-4ec3-84c6-abe6848bb492
 Kernel Version:		4.7.0-coreos
 OS Image:			CoreOS 1122.0.0 (MoreOS)
 Operating System:		linux
 Architecture:			amd64
 Container Runtime Version:	docker://1.11.2
 Kubelet Version:		v1.3.4+coreos.0
 Kube-Proxy Version:		v1.3.4+coreos.0
ExternalID:			node3.example.com
Non-terminated Pods:		(3 in total)
  Namespace			Name						CPU Requests	CPU Limits	Memory Requests	Memory Limits
  ---------			----						------------	----------	---------------	-------------
  kube-system			heapster-v1.1.0-3647315203-yvtx8		158m (15%)	158m (15%)	364Mi (36%)	364Mi (36%)
  kube-system			kube-proxy-node3.example.com			0 (0%)		0 (0%)		0 (0%)		0 (0%)
  kube-system			kubernetes-dashboard-v1.1.0-lloak		100m (10%)	100m (10%)	50Mi (5%)	50Mi (5%)
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted. More info: http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md)
  CPU Requests	CPU Limits	Memory Requests	Memory Limits
  ------------	----------	---------------	-------------
  258m (25%)	258m (25%)	414Mi (41%)	414Mi (41%)
Events:
  FirstSeen	LastSeen	Count	From				SubobjectPath	Type		Reason			Message
  ---------	--------	-----	----				-------------	--------	------			-------
  3m		3m		1	{kubelet node3.example.com}			Normal		Starting		Starting kubelet.
  3m		2m		23	{kubelet node3.example.com}			Normal		NodeHasSufficientDisk	Node node3.example.com status is now: NodeHasSufficientDisk
  3m		2m		23	{kubelet node3.example.com}			Normal		NodeHasSufficientMemory	Node node3.example.com status is now: NodeHasSufficientMemory
  2m		2m		1	{controllermanager }				Normal		RegisteredNode		Node node3.example.com event: Registered Node node3.example.com in NodeController
```