### PR TITLE
examples: Use universal root filesystem

### DIFF
--- a/Documentation/ignition.md
+++ b/Documentation/ignition.md
@@ -43,7 +43,7 @@ Maintain readable inline file contents in Fuze:
 ...
 files:
   - path: /etc/foo.conf
-    filesystem: rootfs
+    filesystem: root
     contents:
       inline: |
         foo bar
@@ -65,7 +65,7 @@ ignition/format-disk.yaml.tmpl:
           partitions:
             - label: ROOT
       filesystems:
-        - name: rootfs
+        - name: root
           mount:
             device: "/dev/sda1"
             format: "ext4"
@@ -74,7 +74,7 @@ ignition/format-disk.yaml.tmpl:
               options:
                 - "-LROOT"
       files:
-        - filesystem: rootfs
+        - filesystem: root
           path: /home/core/foo
           mode: 0644
           user:
@@ -118,7 +118,7 @@ The Ignition config response (formatted) to a query `/ignition?label=value` for 
         ],
         "filesystems": [
           {
-            "name": "rootfs",
+            "name": "root",
             "mount": {
               "device": "/dev/sda1",
               "format": "ext4",
@@ -133,7 +133,7 @@ The Ignition config response (formatted) to a query `/ignition?label=value` for 
         ],
         "files": [
           {
-            "filesystem": "rootfs",
+            "filesystem": "root",
             "path": "/home/core/foo",
             "contents": {
               "source": "data:,Example%20file%20contents%0A",

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -76,7 +76,7 @@ storage:
       partitions:
         - label: ROOT
   filesystems:
-    - name: rootfs
+    - name: root
       mount:
         device: "/dev/sda1"
         format: "ext4"
@@ -84,28 +84,22 @@ storage:
           force: true
           options:
             - "-LROOT"
-  {{else}}
-  filesystems:
-    - name: rootfs
-      mount:
-        device: "/dev/disk/by-label/ROOT"
-        format: "ext4"
   {{end}}
   files:
     - path: /etc/kubernetes/empty
-      filesystem: rootfs
+      filesystem: root
       mode: 0644
       contents:
         inline: |
           empty
     - path: /etc/hostname
-      filesystem: rootfs
+      filesystem: root
       mode: 0644
       contents:
         inline:
           {{.domain_name}}
     - path: /home/core/bootkube-start
-      filesystem: rootfs
+      filesystem: root
       mode: 0544
       user:
         id: 500
@@ -126,7 +120,7 @@ storage:
             $RKT_OPTS \
             ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} --net=host --exec=/bootkube -- start --asset-dir=/assets --etcd-server=http://127.0.0.1:2379 "$@"
     - path: /opt/init-flannel
-      filesystem: rootfs
+      filesystem: root
       mode: 0544
       contents:
         inline: |

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -66,7 +66,7 @@ storage:
       partitions:
         - label: ROOT
   filesystems:
-    - name: rootfs
+    - name: root
       mount:
         device: "/dev/sda1"
         format: "ext4"
@@ -74,22 +74,16 @@ storage:
           force: true
           options:
             - "-LROOT"
-  {{else}}
-  filesystems:
-    - name: rootfs
-      mount:
-        device: "/dev/disk/by-label/ROOT"
-        format: "ext4"
   {{end}}
   files:
     - path: /etc/kubernetes/empty
-      filesystem: rootfs
+      filesystem: root
       mode: 0644
       contents:
         inline: |
           empty
     - path: /etc/hostname
-      filesystem: rootfs
+      filesystem: root
       mode: 0644
       contents:
         inline:

--- a/examples/ignition/format-disk.yaml
+++ b/examples/ignition/format-disk.yaml
@@ -7,7 +7,7 @@ storage:
         - label: ROOT
           number: 0
   filesystems:
-    - name: rootfs
+    - name: root
       mount:
         device: "/dev/sda1"
         format: "ext4"
@@ -16,7 +16,7 @@ storage:
           options:
             - "-LROOT"
   files:
-    - filesystem: rootfs
+    - filesystem: root
       path: /home/core/foo
       mode: 0644
       user:

--- a/examples/ignition/k8s-master.yaml
+++ b/examples/ignition/k8s-master.yaml
@@ -91,7 +91,7 @@ storage:
       partitions:
         - label: ROOT
   filesystems:
-    - name: rootfs
+    - name: root
       mount:
         device: "/dev/sda1"
         format: "ext4"
@@ -99,16 +99,10 @@ storage:
           force: true
           options:
             - "-LROOT"
-  {{else}}
-  filesystems:
-    - name: rootfs
-      mount:
-        device: "/dev/disk/by-label/ROOT"
-        format: "ext4"
   {{end}}
   files:
     - path: /etc/kubernetes/manifests/kube-proxy.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -136,7 +130,7 @@ storage:
                 path: /usr/share/ca-certificates
               name: ssl-certs-host
     - path: /etc/kubernetes/manifests/kube-apiserver.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -192,12 +186,12 @@ storage:
                 path: /usr/share/ca-certificates
               name: ssl-certs-host
     - path: /etc/flannel/options.env
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           FLANNELD_ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
     - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -242,7 +236,7 @@ storage:
                 path: /usr/share/ca-certificates
               name: ssl-certs-host
     - path: /etc/kubernetes/manifests/kube-scheduler.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -271,7 +265,7 @@ storage:
                 initialDelaySeconds: 15
                 timeoutSeconds: 15
     - path: /srv/kubernetes/manifests/kube-dns-rc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -405,7 +399,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/kube-dns-svc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -440,7 +434,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/heapster-deployment.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -540,7 +534,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/heapster-svc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -567,7 +561,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/kube-dashboard-rc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -630,7 +624,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/kube-dashboard-svc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -657,7 +651,7 @@ storage:
             }
           }
     - path: /opt/init-flannel
-      filesystem: rootfs
+      filesystem: root
       mode: 0544
       contents:
         inline: |
@@ -686,7 +680,7 @@ storage:
           }
           init_flannel
     - path: /opt/k8s-addons
-      filesystem: rootfs
+      filesystem: root
       mode: 0544
       contents:
         inline: |

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -77,7 +77,7 @@ storage:
       partitions:
         - label: ROOT
   filesystems:
-    - name: rootfs
+    - name: root
       mount:
         device: "/dev/sda1"
         format: "ext4"
@@ -85,16 +85,10 @@ storage:
           force: true
           options:
             - "-LROOT"
-  {{else}}
-  filesystems:
-    - name: rootfs
-      mount:
-        device: "/dev/disk/by-label/ROOT"
-        format: "ext4"
   {{end}}
   files:
     - path: /etc/kubernetes/worker-kubeconfig.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -115,7 +109,7 @@ storage:
             name: kubelet-context
           current-context: kubelet-context
     - path: /etc/kubernetes/manifests/kube-proxy.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -155,7 +149,7 @@ storage:
                 hostPath:
                   path: "/etc/kubernetes/ssl"
     - path: /etc/flannel/options.env
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           FLANNELD_ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}

--- a/examples/ignition/rktnetes-controller.yaml
+++ b/examples/ignition/rktnetes-controller.yaml
@@ -132,7 +132,7 @@ storage:
       partitions:
         - label: ROOT
   filesystems:
-    - name: rootfs
+    - name: root
       mount:
         device: "/dev/sda1"
         format: "ext4"
@@ -140,16 +140,10 @@ storage:
           force: true
           options:
             - "-LROOT"
-  {{else}}
-  filesystems:
-    - name: rootfs
-      mount:
-        device: "/dev/disk/by-label/ROOT"
-        format: "ext4"
   {{end}}
   files:
     - path: /etc/kubernetes/cni/net.d/10-flannel.conf
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -160,7 +154,7 @@ storage:
               }
           }
     - path: /etc/kubernetes/manifests/kube-proxy.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -196,7 +190,7 @@ storage:
                 path: /var/run/dbus
               name: dbus
     - path: /etc/kubernetes/manifests/kube-apiserver.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -252,12 +246,12 @@ storage:
                 path: /usr/share/ca-certificates
               name: ssl-certs-host
     - path: /etc/flannel/options.env
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           FLANNELD_ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
     - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -302,7 +296,7 @@ storage:
                 path: /usr/share/ca-certificates
               name: ssl-certs-host
     - path: /etc/kubernetes/manifests/kube-scheduler.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -331,7 +325,7 @@ storage:
                 initialDelaySeconds: 15
                 timeoutSeconds: 15
     - path: /srv/kubernetes/manifests/kube-dns-rc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -465,7 +459,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/kube-dns-svc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -500,7 +494,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/heapster-deployment.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -600,7 +594,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/heapster-svc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -627,7 +621,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/kube-dashboard-rc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -690,7 +684,7 @@ storage:
             }
           }
     - path: /srv/kubernetes/manifests/kube-dashboard-svc.json
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -717,7 +711,7 @@ storage:
             }
           }
     - path: /opt/init-flannel
-      filesystem: rootfs
+      filesystem: root
       mode: 0544
       contents:
         inline: |
@@ -746,7 +740,7 @@ storage:
           }
           init_flannel
     - path: /opt/bin/host-rkt
-      filesystem: rootfs
+      filesystem: root
       mode: 0544
       contents:
         inline: |
@@ -761,7 +755,7 @@ storage:
           # https://github.com/coreos/rkt/issues/2878
           exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
     - path: /opt/k8s-addons
-      filesystem: rootfs
+      filesystem: root
       mode: 0544
       contents:
         inline: |

--- a/examples/ignition/rktnetes-worker.yaml
+++ b/examples/ignition/rktnetes-worker.yaml
@@ -118,7 +118,7 @@ storage:
       partitions:
         - label: ROOT
   filesystems:
-    - name: rootfs
+    - name: root
       mount:
         device: "/dev/sda1"
         format: "ext4"
@@ -126,16 +126,10 @@ storage:
           force: true
           options:
             - "-LROOT"
-  {{else}}
-  filesystems:
-    - name: rootfs
-      mount:
-        device: "/dev/disk/by-label/ROOT"
-        format: "ext4"
   {{end}}
   files:
     - path: /etc/kubernetes/cni/net.d/10-flannel.conf
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           {
@@ -146,7 +140,7 @@ storage:
               }
           }
     - path: /etc/kubernetes/worker-kubeconfig.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -167,7 +161,7 @@ storage:
             name: kubelet-context
           current-context: kubelet-context
     - path: /etc/kubernetes/manifests/kube-proxy.yaml
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           apiVersion: v1
@@ -215,12 +209,12 @@ storage:
                   path: /var/run/dbus
                 name: dbus
     - path: /etc/flannel/options.env
-      filesystem: rootfs
+      filesystem: root
       contents:
         inline: |
           FLANNELD_ETCD_ENDPOINTS={{.k8s_etcd_endpoints}}
     - path: /opt/bin/host-rkt
-      filesystem: rootfs
+      filesystem: root
       mode: 0544
       contents:
         inline: |

--- a/examples/ignition/torus.yaml
+++ b/examples/ignition/torus.yaml
@@ -60,7 +60,7 @@ storage:
       partitions:
         - label: ROOT
   filesystems:
-    - name: rootfs
+    - name: root
       mount:
         device: "/dev/sda1"
         format: "ext4"
@@ -68,12 +68,6 @@ storage:
           force: true
           options:
             - "-LROOT"
-  {{else}}
-  filesystems:
-    - name: rootfs
-      mount:
-        device: "/dev/disk/by-label/ROOT"
-        format: "ext4"
   {{end}}
 
 {{ if index . "ssh_authorized_keys" }}


### PR DESCRIPTION
* Use the "root" filesystem from the Ignition universal base config (path /sysroot)
* No need for custom named filesystem anymore
* https://coreos.com/ignition/docs/latest/examples.html#create-files-on-the-root-filesystem

wip: Update other reference clusters to replace "rootfs" with "root".
cc : @crawford