### PR TITLE
Update and add to etcd3 example clusters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 * Add Kubernetes with rkt container runtime (i.e. rktnetes)
 * Upgrade Kubernetes v1.3.4 (static manifest) example clusters
 * Upgrade Kubernetes v1.3.4 (self-hosted) example cluster
+* Add etcd3 example cluster (PXE in-RAM or install to disk)
 * Use DNS names (instead of IPs) in example clusters (except bootkube)
 
 ## v0.4.0 (2016-07-21)

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ These examples network boot and provision machines into CoreOS clusters using `b
 | etcd | iPXE boot a 3 node etcd cluster and proxy | alpha/1109.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
 | etcd-install | Install a 3-node etcd cluster to disk | alpha/1109.1.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
 | etcd3 | Install a 3-node etcd3 cluster | alpha/1109.1.0 | RAM | None |
+| etcd3-install | Install a 3-node etcd3 cluster to disk | alpha/1109.1.0 | Disk | None |
 | k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
 | k8s-install | Install a Kubernetes cluster to disk | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
 | rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (known bugs, experimental) | alpha/1122.0.0 | Disk | None |

--- a/examples/groups/etcd3-install/install.json
+++ b/examples/groups/etcd3-install/install.json
@@ -1,0 +1,11 @@
+{
+  "id": "coreos-install",
+  "name": "CoreOS Install",
+  "profile": "install-reboot",
+  "metadata": {
+    "coreos_channel": "alpha",
+    "coreos_version": "1109.1.0",
+    "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
+    "baseurl": "http://bootcfg.foo:8080/assets/coreos"
+  }
+}

--- a/examples/groups/etcd3-install/node1.json
+++ b/examples/groups/etcd3-install/node1.json
@@ -1,0 +1,14 @@
+{
+  "id": "node1",
+  "name": "etcd Node 1",
+  "profile": "etcd3",
+  "selector": {
+    "mac": "52:54:00:a1:9c:ae",
+    "os": "installed"
+  },
+  "metadata": {
+    "domain_name": "node1.example.com",
+    "etcd_name": "node1",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
+  }
+}

--- a/examples/groups/etcd3-install/node2.json
+++ b/examples/groups/etcd3-install/node2.json
@@ -1,0 +1,14 @@
+{
+  "id": "node2",
+  "name": "etcd Node 2",
+  "profile": "etcd3",
+  "selector": {
+    "mac": "52:54:00:b2:2f:86",
+    "os": "installed"
+  },
+  "metadata": {
+    "domain_name": "node2.example.com",
+    "etcd_name": "node2",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
+  }
+}

--- a/examples/groups/etcd3-install/node3.json
+++ b/examples/groups/etcd3-install/node3.json
@@ -1,0 +1,14 @@
+{
+  "id": "node3",
+  "name": "etcd Node 3",
+  "profile": "etcd3",
+  "selector": {
+    "mac": "52:54:00:c3:61:77",
+    "os": "installed"
+  },
+  "metadata": {
+    "domain_name": "node3.example.com",
+    "etcd_name": "node3",
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
+  }
+}

--- a/examples/groups/etcd3-install/proxy.json
+++ b/examples/groups/etcd3-install/proxy.json
@@ -1,0 +1,11 @@
+{
+  "id": "default",
+  "name": "default",
+  "profile": "etcd-proxy",
+  "selector": {
+    "os": "installed"
+  },
+  "metadata": {
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
+  }
+}

--- a/examples/ignition/etcd3-proxy.yaml
+++ b/examples/ignition/etcd3-proxy.yaml
@@ -8,6 +8,7 @@ systemd:
         Description=etcd3
         Conflicts=etcd2.service
         [Service]
+        Type=notify
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf"
         ExecStartPre=/usr/bin/mkdir -p /var/lib/etcd3
         ExecStartPre=/usr/bin/rkt trust --prefix "coreos.com/etcd" --skip-fingerprint-review
@@ -16,13 +17,14 @@ systemd:
           --volume data-dir,kind=host,source=/var/lib/etcd3 \
           --mount volume=data-dir,target=/var/lib/etcd3 \
           $RKT_OPTS \
-          coreos.com/etcd:v3.0.4 -- \
+          coreos.com/etcd:v3.0.6 -- \
           -proxy=on \
           -listen-client-urls=http://0.0.0.0:2379 \
           -initial-cluster={{.etcd_initial_cluster}}
         Restart=always
         RestartSec=0
         LimitNOFILE=40000
+        TimeoutStartSec=0
         [Install]
         WantedBy=multi-user.target
 

--- a/examples/ignition/etcd3.yaml
+++ b/examples/ignition/etcd3.yaml
@@ -5,6 +5,7 @@ systemd:
       enable: true
       contents: |
         [Unit]
+        Type=notify
         Description=etcd3
         Conflicts=etcd2.service
         [Service]
@@ -16,7 +17,7 @@ systemd:
           --volume data-dir,kind=host,source=/var/lib/etcd3 \
           --mount volume=data-dir,target=/var/lib/etcd3 \
           $RKT_OPTS \
-          coreos.com/etcd:v3.0.4 -- \
+          coreos.com/etcd:v3.0.6 -- \
           -name={{.etcd_name}} \
           -advertise-client-urls=http://{{.domain_name}}:2379 \
           -initial-advertise-peer-urls=http://{{.domain_name}}:2380 \
@@ -27,6 +28,7 @@ systemd:
         Restart=always
         RestartSec=10
         LimitNOFILE=40000
+        TimeoutStartSec=0
         [Install]
         WantedBy=multi-user.target
 


### PR DESCRIPTION
* Use notify service type so dependent services don't start immediately
* Add etcd3-install example cluster
    * etcd3-install installs CoreOS to disk and sets up a 3-node etcd3 cluster
    * Additional machines are setup as etcd3 proxies

cc @gyuho