### PR TITLE
examples: Update example clusters to CoreOS 1153.0.0

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -32,8 +32,8 @@ Finds the profile for the machine and renders the network boot config (kernel, o
 **Response**
 
     #!ipxe
-    kernel /assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz coreos.config.url=http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.first_boot=1 coreos.autologin
-    initrd  /assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz
+    kernel /assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz coreos.config.url=http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.first_boot=1 coreos.autologin
+    initrd  /assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz
     boot
 
 ## GRUB2
@@ -56,9 +56,9 @@ Finds the profile for the machine and renders the network boot config as a GRUB 
     timeout=1
     menuentry "CoreOS" {
     echo "Loading kernel"
-    linuxefi "(http;bootcfg.foo:8080)/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://bootcfg.foo:8080/ignition" "coreos.first_boot"
+    linuxefi "(http;bootcfg.foo:8080)/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://bootcfg.foo:8080/ignition" "coreos.first_boot"
     echo "Loading initrd"
-    initrdefi "(http;bootcfg.foo:8080)/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"
+    initrdefi "(http;bootcfg.foo:8080)/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"
     }
 
 ## Pixiecore
@@ -76,8 +76,8 @@ Finds the profile matching the machine and renders the network boot config as JS
 **Response**
 
     {
-      "kernel":"/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-      "initrd":["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+      "kernel":"/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+      "initrd":["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
       "cmdline":{
         "cloud-config-url":"http://bootcfg.foo/cloud?mac=ADDRESS",
         "coreos.autologin":""
@@ -228,7 +228,7 @@ If you need to serve static assets (e.g. kernel, initrd), `bootcfg` can serve ar
         └── 1109.1.0
             ├── coreos_production_pxe.vmlinuz
             └── coreos_production_pxe_image.cpio.gz
-        └── 1053.2.0
+        └── 1153.0.0
             ├── coreos_production_pxe.vmlinuz
             └── coreos_production_pxe_image.cpio.gz
 

--- a/Documentation/bootcfg.md
+++ b/Documentation/bootcfg.md
@@ -62,8 +62,8 @@ Profiles reference an Ignition config, Cloud-Config, and/or generic config by na
       "ignition_id": "etcd.yaml"
       "generic_id": "some-service.cfg",
       "boot": {
-        "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+        "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+        "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
         "cmdline": {
           "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
           "coreos.autologin": "",

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -28,7 +28,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
+    ./scripts/get-coreos alpha 1153.0.0 ./examples/assets
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 
@@ -57,15 +57,11 @@ We're ready to use [bootkube](https://github.com/coreos/bootkube) to create a te
 Secure copy the `kubeconfig` to `/etc/kuberentes/kubeconfig` on **every** node (i.e. 172.15.0.21-23 for metal0 or 172.17.0.21-23 for docker0).
 
     scp assets/auth/kubeconfig core@172.15.0.21:/home/core/kubeconfig
-    ssh core@172.15.0.21
-    sudo mv kubeconfig /etc/kubernetes/kubeconfig
+    ssh core@172.15.0.21 'sudo mv kubeconfig /etc/kubernetes/kubeconfig'
 
-Secure copy the `bootkube` generated assets to any one of the controller nodes.
+Secure copy the `bootkube` generated assets to any controller node and run `bootkube-start`.
 
     scp -r assets core@172.15.0.21:/home/core/assets
-
-SSH to the chosen controller node and bootstrap the cluster with `bootkube-start`.
-
     ssh core@172.15.0.21 'sudo ./bootkube-start'
 
 Watch the temporary control plane logs until the scheduled kubelet takes over in place of the runonce host kubelet.

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -175,7 +175,7 @@ Certificate chain
 
 ```sh
 $ cd scripts
-$ ./get-coreos alpha 1109.1.0 .     # note the "." 3rd argument
+$ ./get-coreos alpha 1153.0.0 .     # note the "." 3rd argument
 ```
 
 Move the images to `/var/lib/bootcfg/assets`,
@@ -187,7 +187,7 @@ $ sudo cp -r coreos /var/lib/bootcfg/assets
 ```
 /var/lib/bootcfg/assets/
 ├── coreos
-│   └── 1109.1.0
+│   └── 1153.0.0
 │       ├── CoreOS_Image_Signing_Key.asc
 │       ├── coreos_production_image.bin.bz2
 │       ├── coreos_production_image.bin.bz2.sig
@@ -200,7 +200,7 @@ $ sudo cp -r coreos /var/lib/bootcfg/assets
 and verify the images are acessible.
 
 ```
-$ curl http://bootcfg.example.com:8080/assets/coreos/1109.1.0/
+$ curl http://bootcfg.example.com:8080/assets/coreos/1153.0.0/
 <pre>...
 ```
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -24,7 +24,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
 
 Download CoreOS image assets referenced by the `etcd-docker` [example](../examples) to `examples/assets`.
 
-    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
+    ./scripts/get-coreos alpha 1153.0.0 ./examples/assets
 
 ## Containers
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -26,7 +26,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
 
 Download CoreOS image assets referenced by the `etcd` [example](../examples) to `examples/assets`.
 
-    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
+    ./scripts/get-coreos alpha 1153.0.0 ./examples/assets
 
 Define the `metal0` virtual bridge with [CNI](https://github.com/appc/cni).
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -23,7 +23,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
+    ./scripts/get-coreos alpha 1153.0.0 ./examples/assets
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 

--- a/Documentation/torus.md
+++ b/Documentation/torus.md
@@ -22,7 +22,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 1109.1.0 ./examples/assets
+    ./scripts/get-coreos alpha 1153.0.0 ./examples/assets
 
 ## Containers
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,19 +5,19 @@ These examples network boot and provision machines into CoreOS clusters using `b
 
 | Name       | Description | CoreOS Version | FS | Docs | 
 |------------|-------------|----------------|----|-----------|
-| pxe | CoreOS via iPXE | alpha/1109.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| grub | CoreOS via GRUB2 Netboot | alpha/1109.1.0 | RAM | NA |
-| pxe-disk | CoreOS via iPXE, with a root filesystem | alpha/1109.1.0 | Disk | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| etcd | iPXE boot a 3 node etcd cluster and proxy | alpha/1109.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
-| etcd-install | Install a 3-node etcd cluster to disk | alpha/1109.1.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
-| etcd3 | Install a 3-node etcd3 cluster | alpha/1109.1.0 | RAM | None |
-| etcd3-install | Install a 3-node etcd3 cluster to disk | alpha/1109.1.0 | Disk | None |
-| k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| k8s-install | Install a Kubernetes cluster to disk | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | alpha/1151.0.0 | Disk | None |
-| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| torus | Torus distributed storage | alpha/1109.1.0 | Disk | [tutorial](../Documentation/torus.md) |
+| pxe | CoreOS via iPXE | alpha/1153.0.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| grub | CoreOS via GRUB2 Netboot | alpha/1153.0.0 | RAM | NA |
+| pxe-disk | CoreOS via iPXE, with a root filesystem | alpha/1153.0.0 | Disk | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| etcd | iPXE boot a 3 node etcd cluster and proxy | alpha/1153.0.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
+| etcd-install | Install a 3-node etcd cluster to disk | alpha/1153.0.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
+| etcd3 | Install a 3-node etcd3 cluster | alpha/1153.0.0 | RAM | None |
+| etcd3-install | Install a 3-node etcd3 cluster to disk | alpha/1153.0.0 | Disk | None |
+| k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1153.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| k8s-install | Install a Kubernetes cluster to disk | alpha/1153.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | alpha/1153.0.0 | Disk | None |
+| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1153.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1153.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| torus | Torus distributed storage | alpha/1153.0.0 | Disk | [tutorial](../Documentation/torus.md) |
 
 ## Tutorials
 

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "1109.1.0",
+    "coreos_version": "1153.0.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/etcd-install/install.json
+++ b/examples/groups/etcd-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "1109.1.0",
+    "coreos_version": "1153.0.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/etcd3-install/install.json
+++ b/examples/groups/etcd3-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "1109.1.0",
+    "coreos_version": "1153.0.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/k8s-install/install.json
+++ b/examples/groups/k8s-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "1109.1.0",
+    "coreos_version": "1153.0.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -2,8 +2,8 @@
   "id": "bootkube-controller",
   "name": "bootkube Ready Controller",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -2,8 +2,8 @@
   "id": "bootkube-worker",
   "name": "bootkube Ready Worker",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/etcd-proxy.json
+++ b/examples/profiles/etcd-proxy.json
@@ -2,8 +2,8 @@
   "id": "etcd-proxy",
   "name": "etcd-proxy",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/etcd.json
+++ b/examples/profiles/etcd.json
@@ -2,8 +2,8 @@
   "id": "etcd",
   "name": "etcd",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/etcd3-proxy.json
+++ b/examples/profiles/etcd3-proxy.json
@@ -2,8 +2,8 @@
   "id": "etcd3-proxy",
   "name": "etcd3-proxy",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/etcd3.json
+++ b/examples/profiles/etcd3.json
@@ -2,8 +2,8 @@
   "id": "etcd3",
   "name": "etcd3",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/grub.json
+++ b/examples/profiles/grub.json
@@ -2,8 +2,8 @@
   "id": "grub",
   "name": "CoreOS via GRUB2",
   "boot": {
-    "kernel": "(http;bootcfg.foo:8080)/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["(http;bootcfg.foo:8080)/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "(http;bootcfg.foo:8080)/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["(http;bootcfg.foo:8080)/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition",
       "coreos.autologin": "",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -2,8 +2,8 @@
   "id": "install-reboot",
   "name": "Install CoreOS and Reboot",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/install-shutdown.json
+++ b/examples/profiles/install-shutdown.json
@@ -2,8 +2,8 @@
   "id": "install-shutdown",
   "name": "Install CoreOS and Shutdown",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-master-install.json
+++ b/examples/profiles/k8s-master-install.json
@@ -2,8 +2,8 @@
   "id": "k8s-master-install",
   "name": "Kubernetes Master Install",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-master.json
+++ b/examples/profiles/k8s-master.json
@@ -2,8 +2,8 @@
   "id": "k8s-master",
   "name": "Kubernetes Master",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/k8s-worker-install.json
+++ b/examples/profiles/k8s-worker-install.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker-install",
   "name": "Kubernetes Worker Install",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-worker.json
+++ b/examples/profiles/k8s-worker.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/pxe-disk.json
+++ b/examples/profiles/pxe-disk.json
@@ -2,8 +2,8 @@
   "id": "pxe-disk",
   "name": "CoreOS with SSH",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/pxe.json
+++ b/examples/profiles/pxe.json
@@ -3,8 +3,8 @@
 	"name": "CoreOS with SSH",
 	"ignition_id": "ssh.yaml",
 	"boot": {
-		"kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-		"initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+		"kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+		"initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
 		"cmdline": {
 			"coreos.autologin": "",
 			"coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/rktnetes-controller.json
+++ b/examples/profiles/rktnetes-controller.json
@@ -2,8 +2,8 @@
   "id": "rktnetes-controller",
   "name": "Kubernetes Controller",
   "boot": {
-    "kernel": "/assets/coreos/1151.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1151.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/rktnetes-worker.json
+++ b/examples/profiles/rktnetes-worker.json
@@ -2,8 +2,8 @@
   "id": "rktnetes-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1151.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1151.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/torus.json
+++ b/examples/profiles/torus.json
@@ -2,8 +2,8 @@
   "id": "torus",
   "name": "torus",
   "boot": {
-    "kernel": "/assets/coreos/1109.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1109.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,7 @@ This will create:
 
     examples/assets/
     └── coreos
-        └── 1109.1.0
+        └── 1153.0.0
             ├── CoreOS_Image_Signing_Key.asc
             ├── coreos_production_image.bin.bz2
             ├── coreos_production_image.bin.bz2.sig

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -4,7 +4,7 @@
 set -eou pipefail
 
 CHANNEL=${1:-"alpha"}
-VERSION=${2:-"1109.1.0"}
+VERSION=${2:-"1153.0.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 DEST=$DEST_DIR/coreos/$VERSION
 BASE_URL=https://$CHANNEL.release.core-os.net/amd64-usr/$VERSION


### PR DESCRIPTION
* CoreOS 1153.0.0 adds rkt 1.13.0 which should resolve a docker2aci bug in rktnetes https://github.com/coreos/rkt/pull/3026