### PR TITLE
Update rktnetes to 1151.0.0 and fix Docker 1.12 issue

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ These examples network boot and provision machines into CoreOS clusters using `b
 | etcd3-install | Install a 3-node etcd3 cluster to disk | alpha/1109.1.0 | Disk | None |
 | k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
 | k8s-install | Install a Kubernetes cluster to disk | alpha/1109.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (known bugs, experimental) | alpha/1122.0.0 | Disk | None |
+| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | alpha/1151.0.0 | Disk | None |
 | bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1109.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | torus | Torus distributed storage | alpha/1109.1.0 | Disk | [tutorial](../Documentation/torus.md) |

--- a/examples/ignition/rktnetes-controller.yaml
+++ b/examples/ignition/rktnetes-controller.yaml
@@ -29,8 +29,7 @@ systemd:
             Requires=flanneld.service
             After=flanneld.service
             [Service]
-            ExecStart=
-            ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_MTU
+            EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
     - name: k8s-certs@.service
       contents: |
         [Unit]
@@ -153,6 +152,12 @@ storage:
                   "isDefaultGateway": true
               }
           }
+    - path: /etc/kubernetes/cni/docker_opts_cni.env
+      filesystem: root
+      contents:
+        inline: |
+          DOCKER_OPT_BIP=""
+          DOCKER_OPT_IPMASQ=""
     - path: /etc/kubernetes/manifests/kube-proxy.yaml
       filesystem: root
       contents:

--- a/examples/ignition/rktnetes-worker.yaml
+++ b/examples/ignition/rktnetes-worker.yaml
@@ -24,8 +24,7 @@ systemd:
             Requires=flanneld.service
             After=flanneld.service
             [Service]
-            ExecStart=
-            ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// $DOCKER_OPTS $DOCKER_CGROUPS $DOCKER_OPT_MTU
+            EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
     - name: k8s-certs@.service
       contents: |
         [Unit]
@@ -139,6 +138,12 @@ storage:
                   "isDefaultGateway": true
               }
           }
+    - path: /etc/kubernetes/cni/docker_opts_cni.env
+      filesystem: root
+      contents:
+        inline: |
+          DOCKER_OPT_BIP=""
+          DOCKER_OPT_IPMASQ=""
     - path: /etc/kubernetes/worker-kubeconfig.yaml
       filesystem: root
       contents:

--- a/examples/profiles/rktnetes-controller.json
+++ b/examples/profiles/rktnetes-controller.json
@@ -2,8 +2,8 @@
   "id": "rktnetes-controller",
   "name": "Kubernetes Controller",
   "boot": {
-    "kernel": "/assets/coreos/1122.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1122.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1151.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1151.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/rktnetes-worker.json
+++ b/examples/profiles/rktnetes-worker.json
@@ -2,8 +2,8 @@
   "id": "rktnetes-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1122.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1122.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1151.0.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1151.0.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",


### PR DESCRIPTION
* Resolves several docker2aci bugs in rkt 1.11.0 https://github.com/coreos/rkt/pull/3026
* Install to disk (rktnetes-install) is not yet working https://github.com/coreos/bugs/issues/1541
* Docker v1.12 dockerd fails if given the daemon argument (doesn't break rktnetes, but fix is desirable)
* Applies https://github.com/coreos/coreos-kubernetes/pull/642

cc: @pbx0 @euank 