### PR TITLE
scripts/get-coreos: Make gpg binary customisable

### DIFF
--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -3,6 +3,8 @@
 # USAGE: ./scripts/get-coreos channel version dest
 set -eou pipefail
 
+GPG=${GPG:-/usr/bin/gpg}
+
 CHANNEL=${1:-"alpha"}
 VERSION=${2:-"1109.1.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
@@ -24,7 +26,7 @@ echo "Downloading CoreOS $CHANNEL $VERSION images and sigs to $DEST"
 
 echo "CoreOS Image Signing Key"
 curl -# https://coreos.com/security/image-signing-key/CoreOS_Image_Signing_Key.asc -o $DEST/CoreOS_Image_Signing_Key.asc
-gpg --import < "$DEST/CoreOS_Image_Signing_Key.asc" || true
+$GPG --import < "$DEST/CoreOS_Image_Signing_Key.asc" || true
 
 # PXE kernel and sig
 echo "coreos_production_pxe.vmlinuz..."
@@ -45,6 +47,6 @@ echo "coreos_production_image.bin.bz2.sig"
 curl -# $BASE_URL/coreos_production_image.bin.bz2.sig -o $DEST/coreos_production_image.bin.bz2.sig
 
 # verify signatures
-gpg --verify $DEST/coreos_production_pxe.vmlinuz.sig
-gpg --verify $DEST/coreos_production_pxe_image.cpio.gz.sig
-gpg --verify $DEST/coreos_production_image.bin.bz2.sig
+$GPG --verify $DEST/coreos_production_pxe.vmlinuz.sig
+$GPG --verify $DEST/coreos_production_pxe_image.cpio.gz.sig
+$GPG --verify $DEST/coreos_production_image.bin.bz2.sig


### PR DESCRIPTION
Distributions like Debian 8 ship a `gpg` (1.4.x) and a `gpg2` (2.1.x) binary,
 which both use the same config files, and thus cannot be used at the same
 time, due to incompatible options. Thus we allow the user to specify which
 gpg binary they want to use.