### PR TITLE
scripts/devnet: print usage if no arguments are provided

### DIFF
--- a/scripts/devnet
+++ b/scripts/devnet
@@ -17,6 +17,10 @@ if [ "$EUID" -ne 0 ]
 fi
 
 function main {
+  if [ "$#" -ne 1 ]; then
+    usage
+    exit 2
+  fi
   case "$1" in
     "create") create;;
     "destroy") destroy;;


### PR DESCRIPTION
Before:

    $ sudo ./scripts/devnet
    ./scripts/devnet: line 20: $1: unbound variable

After:

    $ sudo ./scripts/devnet
    USAGE: devnet <command>
    Commands:
    	create	create bootcfg and PXE services on the bridge
    	destroy	destroy the services on the bridge