### PR TITLE
examples/rktnetes: Update to CoreOS Beta 1185.1.0

### DIFF
--- a/Documentation/rktnetes.md
+++ b/Documentation/rktnetes.md
@@ -22,7 +22,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos alpha 1153.0.0 ./examples/assets
+    ./scripts/get-coreos beta 1185.1.0 ./examples/assets
 
 Optionally, add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,8 +14,8 @@ These examples network boot and provision machines into CoreOS clusters using `b
 | etcd3-install | Install a 3 node etcd3 cluster to disk | alpha/1153.0.0 | Disk | None |
 | k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | alpha/1153.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
 | k8s-install | Kubernetes cluster, installed to disk | alpha/1153.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | alpha/1153.0.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
-| rktnetes-install | Kubernetes cluster with rkt container runtime, installed to disk (experimental) | alpha/1153.0.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
+| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | beta/1185.0.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
+| rktnetes-install | Kubernetes cluster with rkt container runtime, installed to disk (experimental) | beta/1185.0.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
 | bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1153.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1153.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | torus | Torus distributed storage | alpha/1153.0.0 | Disk | [tutorial](../Documentation/torus.md) |

--- a/examples/groups/rktnetes-install/install.json
+++ b/examples/groups/rktnetes-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "alpha",
-    "coreos_version": "1153.0.0",
+    "coreos_version": "1185.1.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/profiles/rktnetes-controller.json
+++ b/examples/profiles/rktnetes-controller.json
@@ -2,8 +2,8 @@
   "id": "rktnetes-controller",
   "name": "Kubernetes Controller",
   "boot": {
-    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/rktnetes-worker.json
+++ b/examples/profiles/rktnetes-worker.json
@@ -2,8 +2,8 @@
   "id": "rktnetes-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",


### PR DESCRIPTION
* rkt v1.14.0 is needed for rktnetes
* Validated via QEMU/KVM PXE boot
* Validated on lab hardware https://github.com/dghubble/metal/commit/68ac004a2345d04f4577f818f5765b8a0487114c (actually CoreOS Alpha 1192.0.0)

closes #353