### PR TITLE
examples: Update self-hosted Kubernetes to v1.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 * Add Kubernetes example with rkt container runtime (i.e. rktnetes)
 * Upgrade Kubernetes v1.4.0 (static manifest) example clusters
 * Upgrade Kubernetes v1.4.0 (rktnetes) example clusters
-* Upgrade Kubernetes v1.3.4 (self-hosted) example cluster
+* Upgrade Kubernetes v1.4.0 (self-hosted) example cluster
 * Add etcd3 example cluster (PXE in-RAM or install to disk)
 * Use DNS names (instead of IPs) in example clusters (except bootkube)
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -47,8 +47,8 @@ Client machines should boot and provision themselves. Local client VMs should ne
 
 [Install kubectl](https://coreos.com/kubernetes/docs/latest/configure-kubectl.html) on your laptop. Use the generated kubeconfig to access the Kubernetes cluster created on rkt `metal0` or `docker0`.
 
-    $ cd /path/to/coreos-baremetal
-    $ kubectl --kubeconfig=examples/assets/tls/kubeconfig get nodes
+    $ KUBECONFIG=examples/assets/tls/kubeconfig
+    $ kubectl get nodes
     NAME                STATUS    AGE
     node1.example.com   Ready     3m
     node2.example.com   Ready     3m
@@ -56,7 +56,7 @@ Client machines should boot and provision themselves. Local client VMs should ne
 
 Get all pods.
 
-    $ kubectl --kubeconfig=examples/assets/tls/kubeconfig get pods --all-namespaces
+    $ kubectl get pods --all-namespaces
     NAMESPACE     NAME                                        READY     STATUS    RESTARTS   AGE
     kube-system   heapster-v1.2.0-4088228293-k3yn8            2/2       Running   0          3m
     kube-system   kube-apiserver-node1.example.com            1/1       Running   0          4m

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,8 +16,8 @@ These examples network boot and provision machines into CoreOS clusters using `b
 | k8s-install | Kubernetes cluster, installed to disk | alpha/1153.0.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
 | rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | beta/1185.0.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
 | rktnetes-install | Kubernetes cluster with rkt container runtime, installed to disk (experimental) | beta/1185.0.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
-| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | alpha/1153.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | alpha/1153.0.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | beta/1185.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | beta/1185.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | torus | Torus distributed storage | alpha/1153.0.0 | Disk | [tutorial](../Documentation/torus.md) |
 
 ## Tutorials

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -3,8 +3,8 @@
   "name": "CoreOS Install",
   "profile": "install-reboot",
   "metadata": {
-    "coreos_channel": "alpha",
-    "coreos_version": "1153.0.0",
+    "coreos_channel": "beta",
+    "coreos_version": "1185.1.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/rktnetes-install/install.json
+++ b/examples/groups/rktnetes-install/install.json
@@ -3,7 +3,7 @@
   "name": "CoreOS Install",
   "profile": "install-reboot",
   "metadata": {
-    "coreos_channel": "alpha",
+    "coreos_channel": "beta",
     "coreos_version": "1185.1.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -46,7 +46,7 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.3.4_coreos.0
+        Environment=KUBELET_VERSION=v1.4.0_coreos.0
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
@@ -111,7 +111,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.1.4}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.2.0}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/home/core/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -37,7 +37,7 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.3.4_coreos.0
+        Environment=KUBELET_VERSION=v1.4.0_coreos.0
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -2,8 +2,8 @@
   "id": "bootkube-controller",
   "name": "bootkube Ready Controller",
   "boot": {
-    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -2,8 +2,8 @@
   "id": "bootkube-worker",
   "name": "bootkube Ready Worker",
   "boot": {
-    "kernel": "/assets/coreos/1153.0.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1153.0.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",


### PR DESCRIPTION
* Render with [dghubble/bootkube](https://github.com/dghubble/bootkube) fork which supports DNS
* Start with [bootkube](https://github.com/kubernetes-incubator/bootkube) v0.2.0 with rkt
* Update on-host hyperkube to v1.4.0_coreos.0

cc @aaronlevy 