### PR TITLE
Upgrade Kubernetes clusters to v1.4.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # coreos-baremetal bootcfg
 
+#### Examples
+
+* Upgrade Kubernetes v1.4.3 (static manifest) example clusters
+* Upgrade Kubernetes v1.4.3 (rktnetes) example clusters
+* Upgrade Kubernetes v1.4.3 (self-hosted) example cluster
+
 ## Latest
 
 * Add ARM and AMR64 release architectures (#309)

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,7 +1,7 @@
 
 # Self-Hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.4.1 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.4.3 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -1,7 +1,7 @@
 
 # Kubernetes
 
-The Kubernetes example provisions a 3 node Kubernetes v1.4.1 cluster with one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The Kubernetes example provisions a 3 node Kubernetes v1.4.3 cluster with one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 

--- a/Documentation/rktnetes.md
+++ b/Documentation/rktnetes.md
@@ -1,6 +1,6 @@
 # Kubernetes (with rkt)
 
-The `rktnetes` example provisions a 3 node Kubernetes v1.4.1 cluster with [rkt](https://github.com/coreos/rkt) as the container runtime. The cluster has one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The `rktnetes` example provisions a 3 node Kubernetes v1.4.3 cluster with [rkt](https://github.com/coreos/rkt) as the container runtime. The cluster has one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -46,7 +46,7 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.4.1_coreos.0
+        Environment=KUBELET_VERSION=v1.4.3_coreos.0
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
@@ -111,7 +111,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.2.1}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.2.2}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/home/core/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -37,7 +37,7 @@ systemd:
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
         Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.4.1_coreos.0
+        Environment=KUBELET_VERSION=v1.4.3_coreos.0
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests

--- a/examples/ignition/k8s-controller.yaml
+++ b/examples/ignition/k8s-controller.yaml
@@ -58,7 +58,7 @@ systemd:
         Requires=k8s-assets.target
         After=k8s-assets.target
         [Service]
-        Environment=KUBELET_VERSION=v1.4.1_coreos.0
+        Environment=KUBELET_VERSION=v1.4.3_coreos.0
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
           --volume var-log,kind=host,source=/var/log \
@@ -139,7 +139,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-proxy
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - proxy
@@ -167,7 +167,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-apiserver
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - apiserver
@@ -227,7 +227,7 @@ storage:
           spec:
             containers:
             - name: kube-controller-manager
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - controller-manager
@@ -273,7 +273,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-scheduler
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - scheduler

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -52,7 +52,7 @@ systemd:
         Requires=k8s-assets.target
         After=k8s-assets.target
         [Service]
-        Environment=KUBELET_VERSION=v1.4.1_coreos.0
+        Environment=KUBELET_VERSION=v1.4.3_coreos.0
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
           --volume var-log,kind=host,source=/var/log \
@@ -146,7 +146,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-proxy
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - proxy

--- a/examples/ignition/rktnetes-controller.yaml
+++ b/examples/ignition/rktnetes-controller.yaml
@@ -58,7 +58,7 @@ systemd:
         Requires=k8s-assets.target
         After=k8s-assets.target
         [Service]
-        Environment=KUBELET_VERSION=v1.4.1_coreos.0
+        Environment=KUBELET_VERSION=v1.4.3_coreos.0
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
           --volume rkt,kind=host,source=/opt/bin/host-rkt \
@@ -176,7 +176,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-proxy
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - proxy
@@ -210,7 +210,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-apiserver
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - apiserver
@@ -270,7 +270,7 @@ storage:
           spec:
             containers:
             - name: kube-controller-manager
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - controller-manager
@@ -316,7 +316,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-scheduler
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - scheduler

--- a/examples/ignition/rktnetes-worker.yaml
+++ b/examples/ignition/rktnetes-worker.yaml
@@ -52,7 +52,7 @@ systemd:
         Requires=k8s-assets.target
         After=k8s-assets.target
         [Service]
-        Environment=KUBELET_VERSION=v1.4.1_coreos.0
+        Environment=KUBELET_VERSION=v1.4.3_coreos.0
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
           --volume rkt,kind=host,source=/opt/bin/host-rkt \
@@ -182,7 +182,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-proxy
-              image: quay.io/coreos/hyperkube:v1.4.1_coreos.0
+              image: quay.io/coreos/hyperkube:v1.4.3_coreos.0
               command:
               - /hyperkube
               - proxy


### PR DESCRIPTION
* Update to fix http://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2016-7075 https://github.com/kubernetes/kubernetes/issues/34517
* Upgrade static Kubernetes to v1.4.3
* Upgrade self-hosted Kubernetes to v1.4.3
* Upgrade rktnetes to v1.4.3
* Self-hosted Kubernetes [Upgrade Guide](https://github.com/coreos/coreos-baremetal/blob/master/Documentation/bootkube-upgrades.md) for existing clusters

Closes #366