### PR TITLE
examples: Use Kubelet --pod-manifest-path and EnvironmentFile

### DIFF
--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -45,8 +45,7 @@ systemd:
         Wants=flanneld.service
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
-        Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.4.3_coreos.0
+        EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
@@ -56,7 +55,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention \
-          --config=/etc/kubernetes/manifests \
+          --pod-manifest-path=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --node-labels=master=true \
@@ -86,12 +85,13 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/empty
+    - path: /etc/kubernetes/kubelet.env
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          empty
+          KUBELET_ACI=quay.io/coreos/hyperkube
+          KUBELET_VERSION=v1.4.3_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -36,8 +36,7 @@ systemd:
         Wants=flanneld.service
         [Service]
         Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
-        Environment=KUBELET_ACI=quay.io/coreos/hyperkube
-        Environment=KUBELET_VERSION=v1.4.3_coreos.0
+        EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
@@ -47,7 +46,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention \
-          --config=/etc/kubernetes/manifests \
+          --pod-manifest-path=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --minimum-container-ttl-duration=6m0s \
@@ -76,12 +75,13 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/empty
+    - path: /etc/kubernetes/kubelet.env
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          empty
+          KUBELET_ACI=quay.io/coreos/hyperkube
+          KUBELET_VERSION=v1.4.3_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/ignition/k8s-controller.yaml
+++ b/examples/ignition/k8s-controller.yaml
@@ -72,7 +72,7 @@ systemd:
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --network-plugin=cni \
           --allow-privileged=true \
-          --config=/etc/kubernetes/manifests \
+          --pod-manifest-path=/etc/kubernetes/manifests \
           --hostname-override={{.domain_name}} \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -65,7 +65,7 @@ systemd:
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --network-plugin=cni \
           --allow-privileged=true \
-          --config=/etc/kubernetes/manifests \
+          --pod-manifest-path=/etc/kubernetes/manifests \
           --hostname-override={{.domain_name}} \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local \

--- a/examples/ignition/rktnetes-controller.yaml
+++ b/examples/ignition/rktnetes-controller.yaml
@@ -81,7 +81,7 @@ systemd:
           --rkt-path=/usr/bin/rkt \
           --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
           --allow-privileged=true \
-          --config=/etc/kubernetes/manifests \
+          --pod-manifest-path=/etc/kubernetes/manifests \
           --hostname-override={{.domain_name}} \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local

--- a/examples/ignition/rktnetes-worker.yaml
+++ b/examples/ignition/rktnetes-worker.yaml
@@ -73,7 +73,7 @@ systemd:
           --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
           --register-node=true \
           --allow-privileged=true \
-          --config=/etc/kubernetes/manifests \
+          --pod-manifest-path=/etc/kubernetes/manifests \
           --hostname-override={{.domain_name}} \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local \


### PR DESCRIPTION
* Use the Kubelet `--pod-manifest-path`, `--config` is deprecated in Kubernetes 1.4+
* Self-hosted Kubernetes clusters expect the Kubelet ACI and VERSION to be read from an environment file on disk