### PR TITLE
examples/ignition: Set reboot strategy to etcd-lock

### DIFF
--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -29,6 +29,12 @@ systemd:
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
     - name: kubelet.path
       enable: true
       contents: |

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -20,6 +20,12 @@ systemd:
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
     - name: kubelet.path
       enable: true
       contents: |

--- a/examples/ignition/etcd-proxy.yaml
+++ b/examples/ignition/etcd-proxy.yaml
@@ -10,6 +10,12 @@ systemd:
             Environment="ETCD_PROXY=on"
             Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379"
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:

--- a/examples/ignition/etcd.yaml
+++ b/examples/ignition/etcd.yaml
@@ -14,6 +14,12 @@ systemd:
             Environment="ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380"
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:

--- a/examples/ignition/etcd3-proxy.yaml
+++ b/examples/ignition/etcd3-proxy.yaml
@@ -27,6 +27,12 @@ systemd:
         TimeoutStartSec=0
         [Install]
         WantedBy=multi-user.target
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:

--- a/examples/ignition/etcd3.yaml
+++ b/examples/ignition/etcd3.yaml
@@ -31,6 +31,12 @@ systemd:
         TimeoutStartSec=0
         [Install]
         WantedBy=multi-user.target
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:

--- a/examples/ignition/k8s-controller.yaml
+++ b/examples/ignition/k8s-controller.yaml
@@ -30,6 +30,12 @@ systemd:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
     - name: k8s-certs@.service
       contents: |
         [Unit]

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -25,6 +25,12 @@ systemd:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
     - name: k8s-certs@.service
       contents: |
         [Unit]

--- a/examples/ignition/rktnetes-controller.yaml
+++ b/examples/ignition/rktnetes-controller.yaml
@@ -30,6 +30,12 @@ systemd:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
     - name: k8s-certs@.service
       contents: |
         [Unit]

--- a/examples/ignition/rktnetes-worker.yaml
+++ b/examples/ignition/rktnetes-worker.yaml
@@ -25,6 +25,12 @@ systemd:
             After=flanneld.service
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
+    - name: locksmithd.service
+      dropins:
+        - name: 40-etcd-lock.conf
+          contents: |
+            [Service]
+            Environment="REBOOT_STRATEGY=etcd-lock"
     - name: k8s-certs@.service
       contents: |
         [Unit]


### PR DESCRIPTION
* locksmithd should use etcd to lock for reboots
* The default best-effort strategy uses the reboot strategy if etcd isn't running temporarily