### PR TITLE
Documentation: Update deployment docs to use v0.4.1

### DIFF
--- a/Documentation/dev/release.md
+++ b/Documentation/dev/release.md
@@ -20,7 +20,7 @@ Publish the release on Github with release notes.
 
 Build the release tarballs.
 
-    export VERSION=v0.4.0
+    export VERSION=v0.4.1
     make release
 
 ## ACI

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -35,13 +35,13 @@ Run the latest `bootcfg` Docker image from `quay.io/coreos/bootcfg` with the `et
 
 or run the latest tagged release.
 
-    sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/bootcfg:Z -v $PWD/examples/groups/etcd:/var/lib/bootcfg/groups:Z quay.io/coreos/bootcfg:v0.4.0 -address=0.0.0.0:8080 -log-level=debug
+    sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/bootcfg:Z -v $PWD/examples/groups/etcd:/var/lib/bootcfg/groups:Z quay.io/coreos/bootcfg:v0.4.1 -address=0.0.0.0:8080 -log-level=debug
 
-Take a look at the [etcd groups](../examples/groups/etcd-docker) to get an idea of how machines are mapped to Profiles. Explore some endpoints port mapped to localhost:8080.
+Take a look at the [etcd groups](../examples/groups/etcd) to get an idea of how machines are mapped to Profiles. Explore some endpoints exposed by the service, say for QEMU/KVM node1.
 
-* [node1's ipxe](http://127.0.0.1:8080/ipxe?mac=52:54:00:a1:9c:ae)
-* [node1's Ignition](http://127.0.0.1:8080/ignition?mac=52:54:00:a1:9c:ae)
-* [node1's Metadata](http://127.0.0.1:8080/metadata?mac=52:54:00:a1:9c:ae)
+* iPXE [http://127.0.0.1:8080/ipxe?mac=52:54:00:a1:9c:ae](http://127.0.0.1:8080/ipxe?mac=52:54:00:a1:9c:ae)
+* Ignition [http://127.0.0.1:8080/ignition?mac=52:54:00:a1:9c:ae](http://127.0.0.1:8080/ignition?mac=52:54:00:a1:9c:ae)
+* Metadata [http://127.0.0.1:8080/metadata?mac=52:54:00:a1:9c:ae](http://127.0.0.1:8080/metadata?mac=52:54:00:a1:9c:ae)
 
 ## Network
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -62,17 +62,17 @@ Run the latest `bootcfg` ACI with rkt and the `etcd` example.
 
 or run the latest tagged release signed by the [CoreOS App Signing Key](https://coreos.com/security/app-signing-key/).
 
-    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd coreos.com/bootcfg:v0.4.0 -- -address=0.0.0.0:8080 -log-level=debug
+    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd coreos.com/bootcfg:v0.4.1 -- -address=0.0.0.0:8080 -log-level=debug
 
 If you get an error about the IP assignment, stop old pods and run garbage collection.
 
     sudo rkt gc --grace-period=0
 
-Take a look at the [etcd groups](../examples/groups/etcd) to get an idea of how machines are mapped to Profiles. Explore some endpoints exposed by the service.
+Take a look at the [etcd groups](../examples/groups/etcd) to get an idea of how machines are mapped to Profiles. Explore some endpoints exposed by the service, say for QEMU/KVM node1.
 
-* [node1's ipxe](http://172.15.0.2:8080/ipxe?mac=52:54:00:a1:9c:ae)
-* [node1's Ignition](http://172.15.0.2:8080/ignition?mac=52:54:00:a1:9c:ae)
-* [node1's Metadata](http://172.15.0.2:8080/metadata?mac=52:54:00:a1:9c:ae)
+* iPXE [http://172.15.0.2:8080/ipxe?mac=52:54:00:a1:9c:ae](http://172.15.0.2:8080/ipxe?mac=52:54:00:a1:9c:ae)
+* Ignition [http://172.15.0.2:8080/ignition?mac=52:54:00:a1:9c:ae](http://172.15.0.2:8080/ignition?mac=52:54:00:a1:9c:ae)
+* Metadata [http://172.15.0.2:8080/metadata?mac=52:54:00:a1:9c:ae](http://172.15.0.2:8080/metadata?mac=52:54:00:a1:9c:ae)
 
 ## Network
 

--- a/contrib/k8s/bootcfg-deployment.yaml
+++ b/contrib/k8s/bootcfg-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: bootcfg
-          image: quay.io/coreos/bootcfg:v0.4.0
+          image: quay.io/coreos/bootcfg:v0.4.1
           env:
             - {name: BOOTCFG_ADDRESS, value: "0.0.0.0:8080"}
             - {name: BOOTCFG_LOG_LEVEL, value: "debug"}

--- a/contrib/systemd/bootcfg-on-coreos.service
+++ b/contrib/systemd/bootcfg-on-coreos.service
@@ -10,7 +10,7 @@ ExecStart=/usr/bin/rkt run \
   --mount volume=config,target=/etc/bootcfg \
   --volume data,kind=host,source=/var/lib/bootcfg \
   --volume config,kind=host,source=/etc/bootcfg \
-  quay.io/coreos/bootcfg:v0.4.0 -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+  quay.io/coreos/bootcfg:v0.4.1 -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 
 # systemd.exec
 ProtectHome=yes


### PR DESCRIPTION
Although v0.4.1 was just a docs/scripts fix release for Tectonic and arm64, let's be consistent and use v0.4.1 everywhere.

Fix bad link mentioned in #376 while at it. 