### PR TITLE
Update CoreOS and tutorial/docs

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -32,8 +32,8 @@ Finds the profile for the machine and renders the network boot config (kernel, o
 **Response**
 
     #!ipxe
-    kernel /assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz coreos.config.url=http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.first_boot=1 coreos.autologin
-    initrd  /assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz
+    kernel /assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz coreos.config.url=http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.first_boot=1 coreos.autologin
+    initrd  /assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz
     boot
 
 ## GRUB2
@@ -56,9 +56,9 @@ Finds the profile for the machine and renders the network boot config as a GRUB 
     timeout=1
     menuentry "CoreOS" {
     echo "Loading kernel"
-    linuxefi "(http;bootcfg.foo:8080)/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://bootcfg.foo:8080/ignition" "coreos.first_boot"
+    linuxefi "(http;bootcfg.foo:8080)/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://bootcfg.foo:8080/ignition" "coreos.first_boot"
     echo "Loading initrd"
-    initrdefi "(http;bootcfg.foo:8080)/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"
+    initrdefi "(http;bootcfg.foo:8080)/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"
     }
 
 ## Pixiecore
@@ -76,8 +76,8 @@ Finds the profile matching the machine and renders the network boot config as JS
 **Response**
 
     {
-      "kernel":"/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-      "initrd":["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+      "kernel":"/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+      "initrd":["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
       "cmdline":{
         "cloud-config-url":"http://bootcfg.foo/cloud?mac=ADDRESS",
         "coreos.autologin":""
@@ -225,7 +225,7 @@ If you need to serve static assets (e.g. kernel, initrd), `bootcfg` can serve ar
 
     bootcfg.foo/assets/
     └── coreos
-        └── 1185.1.0
+        └── 1185.3.0
             ├── coreos_production_pxe.vmlinuz
             └── coreos_production_pxe_image.cpio.gz
         └── 1153.0.0

--- a/Documentation/bootcfg.md
+++ b/Documentation/bootcfg.md
@@ -62,8 +62,8 @@ Profiles reference an Ignition config, Cloud-Config, and/or generic config by na
       "ignition_id": "etcd.yaml"
       "generic_id": "some-service.cfg",
       "boot": {
-        "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-        "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+        "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+        "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
         "cmdline": {
           "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
           "coreos.autologin": "",

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -27,7 +27,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos beta 1185.1.0 ./examples/assets
+    ./scripts/get-coreos stable 1185.3.0 ./examples/assets
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -10,6 +10,7 @@ Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) o
 * Use rkt or Docker to start `bootcfg`
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
+* `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
 Build and install the [fork of bootkube](https://github.com/dghubble/bootkube), which supports DNS names.
 
@@ -40,8 +41,7 @@ Add your SSH public key to each machine group definition [as shown](../examples/
 
 Use the `bootkube` tool to render Kubernetes manifests and credentials into an `--asset-dir`. Later, `bootkube` will schedule these manifests during bootstrapping and the credentials will be used to access your cluster.
 
-    # If running with docker, use 172.17.0.21 instead of 172.15.0.21
-    bootkube render --asset-dir=assets --api-servers=https://172.15.0.21:443 --api-server-alt-names=DNS=node1.example.com,IP=172.15.0.21
+    bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com
 
 ## Containers
 
@@ -53,17 +53,17 @@ Client machines should boot and provision themselves. Local client VMs should ne
 
 We're ready to use bootkube to create a temporary control plane and bootstrap a self-hosted Kubernetes cluster.
 
-Secure copy the `kubeconfig` to `/etc/kubernetes/kubeconfig` on **every** node (i.e. 172.15.0.21-23 for metal0 or 172.17.0.21-23 for docker0).
+Secure copy the `kubeconfig` to `/etc/kubernetes/kubeconfig` on **every** node which will path activate the `kubelet.service`.
 
-    for node in '172.15.0.21' '172.15.0.22' '172.15.0.23'; do
-        scp assets/auth/kubeconfig core@$node:/home/core/kubeconfig
-        ssh core@$node 'sudo mv kubeconfig /etc/kubernetes/kubeconfig'
+    for node in 'node1' 'node2' 'node3'; do
+        scp assets/auth/kubeconfig core@$node.example.com:/home/core/kubeconfig
+        ssh core@$node.example.com 'sudo mv kubeconfig /etc/kubernetes/kubeconfig'
     done
 
 Secure copy the `bootkube` generated assets to any controller node and run `bootkube-start`.
 
-    scp -r assets core@172.15.0.21:/home/core/assets
-    ssh core@172.15.0.21 'sudo ./bootkube-start'
+    scp -r assets core@node1.example.com:/home/core/assets
+    ssh core@node1.example.com 'sudo ./bootkube-start'
 
 Watch the temporary control plane logs until the scheduled kubelet takes over in place of the on-host kubelet.
 

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -171,7 +171,7 @@ Certificate chain
 Download a recent CoreOS [release](https://coreos.com/releases/) with signatures.
 
 ```sh
-$ ./scripts/get-coreos beta 1192.2.0 .     # note the "." 3rd argument
+$ ./scripts/get-coreos stable 1185.3.0 .     # note the "." 3rd argument
 ```
 
 Move the images to `/var/lib/bootcfg/assets`,
@@ -183,7 +183,7 @@ $ sudo cp -r coreos /var/lib/bootcfg/assets
 ```
 /var/lib/bootcfg/assets/
 ├── coreos
-│   └── 1192.2.0
+│   └── 1185.3.0
 │       ├── CoreOS_Image_Signing_Key.asc
 │       ├── coreos_production_image.bin.bz2
 │       ├── coreos_production_image.bin.bz2.sig
@@ -196,7 +196,7 @@ $ sudo cp -r coreos /var/lib/bootcfg/assets
 and verify the images are acessible.
 
 ```
-$ curl http://bootcfg.example.com:8080/assets/coreos/1185.1.0/
+$ curl http://bootcfg.example.com:8080/assets/coreos/1185.3.0/
 <pre>...
 ```
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -26,6 +26,14 @@ Download CoreOS image assets referenced by the `etcd-docker` [example](../exampl
 
     ./scripts/get-coreos stable 1185.3.0 ./examples/assets
 
+For development convenience, add `/etc/hosts` entries for nodes so they may be referenced by name as you would in production.
+
+    # /etc/hosts
+    ...
+    172.17.0.21 node1.example.com
+    172.17.0.22 node2.example.com
+    172.17.0.23 node3.example.com
+
 ## Containers
 
 Run the latest `bootcfg` Docker image from `quay.io/coreos/bootcfg` with the `etcd-docker` example. The container should receive the IP address 172.17.0.2 on the `docker0` bridge.
@@ -73,7 +81,9 @@ The example profile added autologin so you can verify that etcd works between no
     etcdctl set /message hello
     etcdctl get /message
 
-Clean up the VM machines.
+## Cleanup
+
+Clean up the containers and VM machines.
 
     sudo docker rm -f dnsmasq
     sudo ./scripts/libvirt poweroff
@@ -81,5 +91,5 @@ Clean up the VM machines.
 
 ## Going Further
 
-Learn more about [bootcfg](bootcfg.md) or explore the other [example](../examples) clusters. Try the [k8s-docker example](kubernetes.md) to produce a TLS-authenticated Kubernetes cluster you can access locally with `kubectl`.
+Learn more about [bootcfg](bootcfg.md) or explore the other [example](../examples) clusters. Try the [k8s example](kubernetes.md) to produce a TLS-authenticated Kubernetes cluster you can access locally with `kubectl`.
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -24,7 +24,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
 
 Download CoreOS image assets referenced by the `etcd-docker` [example](../examples) to `examples/assets`.
 
-    ./scripts/get-coreos beta 1185.1.0 ./examples/assets
+    ./scripts/get-coreos stable 1185.3.0 ./examples/assets
 
 ## Containers
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -26,7 +26,7 @@ Clone the [coreos-baremetal](https://github.com/coreos/coreos-baremetal) source 
 
 Download CoreOS image assets referenced by the `etcd` [example](../examples) to `examples/assets`.
 
-    ./scripts/get-coreos beta 1185.1.0 ./examples/assets
+    ./scripts/get-coreos stable 1185.3.0 ./examples/assets
 
 Define the `metal0` virtual bridge with [CNI](https://github.com/appc/cni).
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -54,6 +54,14 @@ On Fedora, add the `metal0` interface to the trusted zone in your firewall confi
 
 After a recent update, you may see a warning that NetworkManager controls the interface. Work-around this using the firewall-config GUI to add `metal0` to the trusted zone.
 
+For development convenience, add `/etc/hosts` entries for nodes so they may be referenced by name as you would in production.
+
+    # /etc/hosts
+    ...
+    172.15.0.21 node1.example.com
+    172.15.0.22 node2.example.com
+    172.15.0.23 node3.example.com
+
 ## Containers
 
 Run the latest `bootcfg` ACI with rkt and the `etcd` example.
@@ -110,6 +118,8 @@ The example profile added autologin so you can verify that etcd works between no
     systemctl status etcd2
     etcdctl set /message hello
     etcdctl get /message
+
+## Cleanup
 
 Press ^] three times to stop a rkt pod. Clean up the VM machines.
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -10,6 +10,7 @@ Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) o
 * Use rkt or Docker to start `bootcfg`
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
+* `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
 ## Examples
 
@@ -27,15 +28,12 @@ Download the CoreOS image assets referenced in the target [profile](../examples/
 
 Optionally, add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 
-Generate a root CA and Kubernetes TLS assets for components (`admin`, `apiserver`, `worker`).
+Generate a root CA and Kubernetes TLS assets for components (`admin`, `apiserver`, `worker`) with SANs for `node1.example.com`, etc.
 
     rm -rf examples/assets/tls
-    # for Kubernetes on CNI metal0 (for rkt)
-    ./scripts/tls/k8s-certgen -d examples/assets/tls -s 172.15.0.21 -m IP.1=10.3.0.1,IP.2=172.15.0.21,DNS.1=node1.example.com -w DNS.1=node2.example.com,DNS.2=node3.example.com
-    # for Kubernetes on docker0 (for docker)
-    ./scripts/tls/k8s-certgen -d examples/assets/tls -s 172.17.0.21 -m IP.1=10.3.0.1,IP.2=172.17.0.21,DNS.1=node1.example.com -w DNS.1=node2.example.com,DNS.2=node3.example.com
+    ./scripts/tls/k8s-certgen
 
-**Note**: TLS assets are served to any machines which request them, which requires a trusted network. Alternately, provisioning may be tweaked to require TLS assets be securely copied to each host. Read about our longer term security plans at [Distributed Trusted Computing](https://coreos.com/blog/coreos-trusted-computing.html).
+**Note**: TLS assets are served to any machines which request them, which requires a trusted network. Alternately, provisioning may be tweaked to require TLS assets be securely copied to each host.
 
 ## Containers
 
@@ -66,7 +64,7 @@ Get all pods.
     kube-system   kube-proxy-node2.example.com                1/1       Running   0          3m
     kube-system   kube-proxy-node3.example.com                1/1       Running   0          3m
     kube-system   kube-scheduler-node1.example.com            1/1       Running   0          3m
-    kube-system   kubernetes-dashboard-v1.4.0-0iy07           1/1       Running   0          4m
+    kube-system   kubernetes-dashboard-v1.4.1-0iy07           1/1       Running   0          4m
 
 ## Kubernetes Dashboard
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -23,7 +23,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos beta 1185.1.0 ./examples/assets
+    ./scripts/get-coreos stable 1185.3.0 ./examples/assets
 
 Optionally, add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 

--- a/Documentation/rktnetes.md
+++ b/Documentation/rktnetes.md
@@ -22,7 +22,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos beta 1185.1.0 ./examples/assets
+    ./scripts/get-coreos stable 1185.3.0 ./examples/assets
 
 Optionally, add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 

--- a/Documentation/rktnetes.md
+++ b/Documentation/rktnetes.md
@@ -9,6 +9,7 @@ Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) o
 * Use rkt or Docker to start `bootcfg`
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
+* `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
 ## Examples
 
@@ -26,15 +27,12 @@ Download the CoreOS image assets referenced in the target [profile](../examples/
 
 Optionally, add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).
 
-Generate a root CA and Kubernetes TLS assets for components (`admin`, `apiserver`, `worker`).
+Generate a root CA and Kubernetes TLS assets for components (`admin`, `apiserver`, `worker`) with SANs for `node1.example.com`, etc.
 
     rm -rf examples/assets/tls
-    # for Kubernetes on CNI metal0 (for rkt)
-    ./scripts/tls/k8s-certgen -d examples/assets/tls -s 172.15.0.21 -m IP.1=10.3.0.1,IP.2=172.15.0.21,DNS.1=node1.example.com -w DNS.1=node2.example.com,DNS.2=node3.example.com
-    # for Kubernetes on docker0 (for docker)
-    ./scripts/tls/k8s-certgen -d examples/assets/tls -s 172.17.0.21 -m IP.1=10.3.0.1,IP.2=172.17.0.21,DNS.1=node1.example.com -w DNS.1=node2.example.com,DNS.2=node3.example.com
+    ./scripts/tls/k8s-certgen
 
-**Note**: TLS assets are served to any machines which request them, which requires a trusted network. Alternately, provisioning may be tweaked to require TLS assets be securely copied to each host. Read about our longer term security plans at [Distributed Trusted Computing](https://coreos.com/blog/coreos-trusted-computing.html).
+**Note**: TLS assets are served to any machines which request them, which requires a trusted network. Alternately, provisioning may be tweaked to require TLS assets be securely copied to each host.
 
 ## Containers
 
@@ -65,7 +63,7 @@ Get all pods.
     kube-system   kube-proxy-node2.example.com                1/1       Running   0          3m
     kube-system   kube-proxy-node3.example.com                1/1       Running   0          3m
     kube-system   kube-scheduler-node1.example.com            1/1       Running   0          3m
-    kube-system   kubernetes-dashboard-v1.4.0-0iy07           1/1       Running   0          4m
+    kube-system   kubernetes-dashboard-v1.4.1-0iy07           1/1       Running   0          4m
 
 ## Kubernetes Dashboard
 

--- a/Documentation/torus.md
+++ b/Documentation/torus.md
@@ -22,7 +22,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
-    ./scripts/get-coreos beta 1185.1.0 ./examples/assets
+    ./scripts/get-coreos stable 1185.3.0 ./examples/assets
 
 ## Containers
 

--- a/Documentation/torus.md
+++ b/Documentation/torus.md
@@ -10,6 +10,7 @@ Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) g
 * Use rkt or Docker to start `bootcfg`
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
+* `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 * Install the Torus [binaries](https://github.com/coreos/torus/releases)
 
 ## Examples
@@ -36,7 +37,7 @@ Create a network boot environment and power-on your machines. Revisit [bootcfg w
 
 Install the Torus [binaries](https://github.com/coreos/torus/releases) on your laptop. Torus uses etcd3 for coordination and metadata storage, so any etcd node in the cluster can be queried with `torusctl`.
 
-    ./torusctl --etcd 172.15.0.21:2379 list-peers
+    ./torusctl --etcd node1.example.com:2379 list-peers
 
 Run `list-peers` to report the status of data nodes in the Torus cluster.
 
@@ -57,11 +58,11 @@ Torus has already initialized its metadata within etcd3 to format the cluster an
 
 Create a new replicated, virtual block device or `volume` on Torus.
 
-    ./torusctl --etcd=172.15.0.21:2379 block create hello 500MiB
+    ./torusctl --etcd=node1.example.com:2379 block create hello 500MiB
 
 List the current volumes,
 
-    ./torusctl --etcd=172.15.0.21:2379 volume list
+    ./torusctl --etcd=node1.example.com:2379 volume list
 
 and verify that `hello` was created.
 
@@ -78,7 +79,7 @@ and verify that `hello` was created.
 Let's attach the Torus volume, create a filesystem, and add some files. Add the `nbd` kernel module.
 
     sudo modprobe nbd
-    sudo ./torusblk --etcd=172.15.0.21:2379 nbd hello
+    sudo ./torusblk --etcd=node1.example.com:2379 nbd hello
 
 In a new shell, create a new filesystem on the volume and mount it on your system.
 
@@ -100,14 +101,14 @@ By default, Torus uses a replication factor of 2. You may write some data and po
 
 Check the Torus data nodes.
 
-    $ ./torusctl --etcd 172.15.0.21:2379 list-peers
+    $ ./torusctl --etcd node1.example.com:2379 list-peers
 
 ```
 +--------------------------+--------------------------------------+---------+--------+--------+---------------+--------------+
 |         ADDRESS          |                 UUID                 |  SIZE   |  USED  | MEMBER |    UPDATED    | REB/REP DATA |
 +--------------------------+--------------------------------------+---------+--------+--------+---------------+--------------+
-| http://172.15.0.21:40000 | 016fad6a-2e23-11e6-8ced-525400a19cae | 1.0 GiB | 22 MiB | OK     | 3 seconds ago | 0 B/sec      |
-| http://172.15.0.22:40000 | 0c67d31c-2e23-11e6-91f5-525400b22f86 | 1.0 GiB | 22 MiB | OK     | 3 seconds ago | 0 B/sec      |
+| http://node1.example.com:40000 | 016fad6a-2e23-11e6-8ced-525400a19cae | 1.0 GiB | 22 MiB | OK     | 3 seconds ago | 0 B/sec      |
+| http://node2.example.com:40000 | 0c67d31c-2e23-11e6-91f5-525400b22f86 | 1.0 GiB | 22 MiB | OK     | 3 seconds ago | 0 B/sec      |
 |                          | 0408cbba-2e23-11e6-9871-525400c36177 | ???     | ???    | DOWN   | Missing       |              |
 +--------------------------+--------------------------------------+---------+--------+--------+---------------+--------------+
 Balanced: true Usage:  2.15%

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,9 +33,13 @@ Get started running `bootcfg` on your Linux machine to network boot and provisio
 * [Torus Storage](../Documentation/torus.md)
 * [Lab Examples](https://github.com/dghubble/metal)
 
+## Autologin
+
+Example profiles pass the `coreos.autologin` kernel argument. This skips the password prompt for development and troubleshooting and should be removed **before production**.
+
 ## SSH Keys
 
-Most examples allow `ssh_authorized_keys` to be added for the `core` user as machine group metadata.
+Example groups allow `ssh_authorized_keys` to be added for the `core` user as metadata. You might also include this directly in your Ignition.
 
     # /var/lib/bootcfg/groups/default.json
     {

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,20 +5,20 @@ These examples network boot and provision machines into CoreOS clusters using `b
 
 | Name       | Description | CoreOS Version | FS | Docs | 
 |------------|-------------|----------------|----|-----------|
-| simple | CoreOS with autologin, using iPXE | beta/1185.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| simple-install | CoreOS Install, using iPXE | beta/1185.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| grub | CoreOS via GRUB2 Netboot | beta/1185.1.0 | RAM | NA |
-| etcd | A 3 node etcd cluster with proxies | beta/1185.1.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
-| etcd-install | Install a 3 node etcd cluster to disk | beta/1185.1.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
-| etcd3 | A 3 node etcd3 cluster with proxies | beta/1185.1.0 | RAM | None |
-| etcd3-install | Install a 3 node etcd3 cluster to disk | beta/1185.1.0 | Disk | None |
-| k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | beta/1185.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| k8s-install | Kubernetes cluster, installed to disk | beta/1185.1.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | beta/1185.1.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
-| rktnetes-install | Kubernetes cluster with rkt container runtime, installed to disk (experimental) | beta/1185.1.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
-| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | beta/1185.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | beta/1185.1.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| torus | Torus distributed storage | beta/1185.1.0 | Disk | [tutorial](../Documentation/torus.md) |
+| simple | CoreOS with autologin, using iPXE | stable/1185.3.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| simple-install | CoreOS Install, using iPXE | stable/1185.3.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| grub | CoreOS via GRUB2 Netboot | stable/1185.3.0 | RAM | NA |
+| etcd | A 3 node etcd cluster with proxies | stable/1185.3.0 | RAM | [reference](https://coreos.com/os/docs/latest/cluster-architectures.html) |
+| etcd-install | Install a 3 node etcd cluster to disk | stable/1185.3.0 | Disk | [reference](https://coreos.com/os/docs/latest/installing-to-disk.html) |
+| etcd3 | A 3 node etcd3 cluster with proxies | stable/1185.3.0 | RAM | None |
+| etcd3-install | Install a 3 node etcd3 cluster to disk | stable/1185.3.0 | Disk | None |
+| k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | stable/1185.3.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| k8s-install | Kubernetes cluster, installed to disk | stable/1185.3.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | stable/1185.3.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
+| rktnetes-install | Kubernetes cluster with rkt container runtime, installed to disk (experimental) | stable/1185.3.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
+| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | stable/1185.3.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | stable/1185.3.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| torus | Torus distributed storage | stable/1185.3.0 | Disk | [tutorial](../Documentation/torus.md) |
 
 ## Tutorials
 

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -3,8 +3,8 @@
   "name": "CoreOS Install",
   "profile": "install-reboot",
   "metadata": {
-    "coreos_channel": "beta",
-    "coreos_version": "1185.1.0",
+    "coreos_channel": "stable",
+    "coreos_version": "1185.3.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/etcd-install/install.json
+++ b/examples/groups/etcd-install/install.json
@@ -3,8 +3,8 @@
   "name": "CoreOS Install",
   "profile": "install-reboot",
   "metadata": {
-    "coreos_channel": "beta",
-    "coreos_version": "1185.1.0",
+    "coreos_channel": "stable",
+    "coreos_version": "1185.3.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/etcd-install/proxy.json
+++ b/examples/groups/etcd-install/proxy.json
@@ -7,6 +7,6 @@
   },
   "metadata": {
     "fleet_metadata": "role=etcd-proxy",
-    "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
+    "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
   }
 }

--- a/examples/groups/etcd3-install/install.json
+++ b/examples/groups/etcd3-install/install.json
@@ -3,8 +3,8 @@
   "name": "CoreOS Install",
   "profile": "install-reboot",
   "metadata": {
-    "coreos_channel": "beta",
-    "coreos_version": "1185.1.0",
+    "coreos_channel": "stable",
+    "coreos_version": "1185.3.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/k8s-install/install.json
+++ b/examples/groups/k8s-install/install.json
@@ -3,8 +3,8 @@
   "name": "CoreOS Install",
   "profile": "install-reboot",
   "metadata": {
-    "coreos_channel": "beta",
-    "coreos_version": "1185.1.0",
+    "coreos_channel": "stable",
+    "coreos_version": "1185.3.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/rktnetes-install/install.json
+++ b/examples/groups/rktnetes-install/install.json
@@ -3,8 +3,8 @@
   "name": "CoreOS Install",
   "profile": "install-reboot",
   "metadata": {
-    "coreos_channel": "beta",
-    "coreos_version": "1185.1.0",
+    "coreos_channel": "stable",
+    "coreos_version": "1185.3.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/groups/simple-install/install.json
+++ b/examples/groups/simple-install/install.json
@@ -3,8 +3,8 @@
   "name": "Simple CoreOS Alpha Install",
   "profile": "simple-install",
   "metadata": {
-    "coreos_channel": "beta",
-    "coreos_version": "1185.1.0",
+    "coreos_channel": "stable",
+    "coreos_version": "1185.3.0",
     "ignition_endpoint": "http://bootcfg.foo:8080/ignition",
     "baseurl": "http://bootcfg.foo:8080/assets/coreos"
   }

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -2,8 +2,8 @@
   "id": "bootkube-controller",
   "name": "bootkube Ready Controller",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -2,8 +2,8 @@
   "id": "bootkube-worker",
   "name": "bootkube Ready Worker",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/etcd-proxy.json
+++ b/examples/profiles/etcd-proxy.json
@@ -2,8 +2,8 @@
   "id": "etcd-proxy",
   "name": "etcd-proxy",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/etcd.json
+++ b/examples/profiles/etcd.json
@@ -2,8 +2,8 @@
   "id": "etcd",
   "name": "etcd",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/etcd3-proxy.json
+++ b/examples/profiles/etcd3-proxy.json
@@ -2,8 +2,8 @@
   "id": "etcd3-proxy",
   "name": "etcd3-proxy",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/etcd3.json
+++ b/examples/profiles/etcd3.json
@@ -2,8 +2,8 @@
   "id": "etcd3",
   "name": "etcd3",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/grub.json
+++ b/examples/profiles/grub.json
@@ -2,8 +2,8 @@
   "id": "grub",
   "name": "CoreOS via GRUB2",
   "boot": {
-    "kernel": "(http;bootcfg.foo:8080)/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["(http;bootcfg.foo:8080)/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "(http;bootcfg.foo:8080)/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["(http;bootcfg.foo:8080)/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition",
       "coreos.autologin": "",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -2,8 +2,8 @@
   "id": "install-reboot",
   "name": "Install CoreOS and Reboot",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/install-shutdown.json
+++ b/examples/profiles/install-shutdown.json
@@ -2,8 +2,8 @@
   "id": "install-shutdown",
   "name": "Install CoreOS and Shutdown",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/k8s-controller.json
+++ b/examples/profiles/k8s-controller.json
@@ -2,8 +2,8 @@
   "id": "k8s-controller",
   "name": "Kubernetes Controller",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/k8s-worker.json
+++ b/examples/profiles/k8s-worker.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/rktnetes-controller.json
+++ b/examples/profiles/rktnetes-controller.json
@@ -2,8 +2,8 @@
   "id": "rktnetes-controller",
   "name": "Kubernetes Controller",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/rktnetes-worker.json
+++ b/examples/profiles/rktnetes-worker.json
@@ -2,8 +2,8 @@
   "id": "rktnetes-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/simple-install.json
+++ b/examples/profiles/simple-install.json
@@ -2,8 +2,8 @@
   "id": "simple-install",
   "name": "Simple CoreOS Alpha Install",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
       "coreos.autologin": "",

--- a/examples/profiles/simple.json
+++ b/examples/profiles/simple.json
@@ -2,8 +2,8 @@
 	"id": "simple",
 	"name": "Simple CoreOS Alpha",
 	"boot": {
-		"kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-		"initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+		"kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+		"initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
 		"cmdline": {
 			"coreos.autologin": "",
 			"coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/examples/profiles/torus.json
+++ b/examples/profiles/torus.json
@@ -2,8 +2,8 @@
   "id": "torus",
   "name": "torus",
   "boot": {
-    "kernel": "/assets/coreos/1185.1.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1185.1.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "cmdline": {
       "root": "/dev/sda1",
       "coreos.config.url": "http://bootcfg.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -8,7 +8,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 EXAMPLE=${2:-}
 BRIDGE=metal0
-COREOS_VERSION=1185.1.0
+COREOS_VERSION=1185.3.0
 BOOTCFG_ARGS=""
 
 if [ "$EUID" -ne 0 ]

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -5,8 +5,8 @@ set -eou pipefail
 
 GPG=${GPG:-/usr/bin/gpg}
 
-CHANNEL=${1:-"beta"}
-VERSION=${2:-"1185.1.0"}
+CHANNEL=${1:-"stable"}
+VERSION=${2:-"1185.3.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 DEST=$DEST_DIR/coreos/$VERSION
 BASE_URL=https://$CHANNEL.release.core-os.net/amd64-usr/$VERSION

--- a/scripts/tls/k8s-certgen
+++ b/scripts/tls/k8s-certgen
@@ -3,16 +3,16 @@
 USAGE="Usage: $(basename $0)
 Options:
   -d DEST     Destination for generated files (default: .examples/assets/tls)
-  -s SERVER   Reachable Server IP for kubeconfig (e.g. 172.15.0.21)
-  -m MASTERS  Master Node Names/Addresses in SAN format (e.g. IP.1=10.3.0.1,IP.2=172.15.0.21).
-  -w WORKERS  Worker Node Names/Addresses in SAN format (e.g. IP.1=172.15.0.22,IP.2=172.15.0.23)
+  -s SERVER   Reachable Server IP for kubeconfig (e.g. node1.example.com)
+  -m MASTERS  Controller Node Names/Addresses in SAN format (e.g. IP.1=10.3.0.1,DNS.1=node1.example.com).
+  -w WORKERS  Worker Node Names/Addresses in SAN format (e.g. DNS.1=node2.example.com,DNS.2=node3.example.com)
   -h          Show help.
 "
 
 DEST="./examples/assets/tls"
-SERVER="172.15.0.21"
-MASTERS="IP.1=10.3.0.1,IP.2=172.15.0.21"
-WORKERS="IP.1=172.15.0.22,IP.2=172.15.0.23"
+SERVER="node1.example.com"
+MASTERS="IP.1=10.3.0.1,DNS.1=node1.example.com"
+WORKERS="DNS.1=node2.example.com,DNS.2=node3.example.com"
 
 while getopts "d:s:m:w:vh" opt; do
   case $opt in


### PR DESCRIPTION
* Update CoreOS to stable 1185.3.0
* Add autologin clarification (must be turned off for prod)
* Use `/etc/hosts` node names in docs. This closes #333 and simplifies various tutorials.