### PR TITLE
fix scripts/tls/kube-conf for darwin OS type

### DIFF
--- a/scripts/tls/kube-conf
+++ b/scripts/tls/kube-conf
@@ -6,7 +6,7 @@ function usage {
 }
 
 function base64_encode {
-  if [[ "$OSTYPE" == "darwin" ]]; then
+  if [[ "$OSTYPE" == darwin* ]]; then
     base64 $1
   else
     base64 -w 0 $1


### PR DESCRIPTION
On my macOS 10.12.1 laptop `OSTYPE=darwin16`. This fix should handle all darwin OSes.