### PR TITLE
Documentation: Change metal0 bridge to 172.18.0.0/24

### DIFF
--- a/Documentation/bootcfg.md
+++ b/Documentation/bootcfg.md
@@ -94,7 +94,7 @@ Create a group definition with a `Profile` to be applied, selectors for matching
       "metadata": {
         "fleet_metadata": "role=etcd,name=node1",
         "etcd_name": "node1",
-        "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
+        "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
       }
     }
 
@@ -105,7 +105,7 @@ Meanwhile, `/var/lib/bootcfg/groups/proxy.json` acts as the default machine grou
       "profile": "etcd-proxy",
       "metadata": {
         "fleet_metadata": "role=etcd-proxy",
-        "etcd_initial_cluster": "node1=http://172.15.0.21:2380,node2=http://172.15.0.22:2380,node3=http://172.15.0.23:2380"
+        "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
       }
     }
 

--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -45,7 +45,7 @@ Run the binary.
 
 Run the latest ACI with rkt.
 
-    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=assets,target=/var/lib/bootcfg/assets --volume assets,kind=host,source=$PWD/examples/assets quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
+    sudo rkt run --mount volume=assets,target=/var/lib/bootcfg/assets --volume assets,kind=host,source=$PWD/examples/assets quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
 
 Run the latest Docker image.
 
@@ -55,7 +55,7 @@ Run the latest Docker image.
 
 Mount `examples` to pre-load the [example](../examples/README.md) machine groups and profiles. Run the container with rkt,
 
-    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
+    sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
 
 or with Docker.
 
@@ -77,11 +77,11 @@ Clients, such as `bootcmd`, verify the server's certificate with a CA bundle pas
 
 Run the ACI with rkt and TLS credentials from `examples/etc/bootcfg`.
 
-    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples,readOnly=true --mount volume=config,target=/etc/bootcfg --volume config,kind=host,source=$PWD/examples/etc/bootcfg --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+    sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples,readOnly=true --mount volume=config,target=/etc/bootcfg --volume config,kind=host,source=$PWD/examples/etc/bootcfg --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 
 A `bootcmd` client can call the gRPC API running at the IP used in the rkt example.
 
-    ./bin/bootcmd profile list --endpoints 172.15.0.2:8081 --ca-file examples/etc/bootcfg/ca.crt --cert-file examples/etc/bootcfg/client.crt --key-file examples/etc/bootcfg/client.key
+    ./bin/bootcmd profile list --endpoints 172.18.0.2:8081 --ca-file examples/etc/bootcfg/ca.crt --cert-file examples/etc/bootcfg/client.crt --key-file examples/etc/bootcfg/client.key
 
 #### With docker
 
@@ -102,7 +102,7 @@ Run with the binary with a test key.
 
 Run the ACI with a test key.
 
-    sudo rkt run --net=metal0:IP=172.15.0.2 --set-env=BOOTCFG_PASSPHRASE=test --mount volume=secrets,target=/secrets --volume secrets,kind=host,source=$PWD/bootcfg/sign/fixtures --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -key-ring-path secrets/secring.gpg
+    sudo rkt run --net=metal0:IP=172.18.0.2 --set-env=BOOTCFG_PASSPHRASE=test --mount volume=secrets,target=/secrets --volume secrets,kind=host,source=$PWD/bootcfg/sign/fixtures --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -key-ring-path secrets/secring.gpg
 
 Run the Docker image with a test key.
 

--- a/Documentation/dev/develop.md
+++ b/Documentation/dev/develop.md
@@ -37,7 +37,7 @@ Run the binary.
 
 Run the ACI with rkt on `metal0`.
 
-    sudo rkt --insecure-options=image run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=config,target=/etc/bootcfg --volume config,kind=host,source=$PWD/examples/etc/bootcfg --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd bootcfg.aci -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+    sudo rkt --insecure-options=image run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=config,target=/etc/bootcfg --volume config,kind=host,source=$PWD/examples/etc/bootcfg --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd bootcfg.aci -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 
 Alternately, run the Docker image on `docker0`.
 
@@ -47,7 +47,7 @@ Alternately, run the Docker image on `docker0`.
 
 Run `bootcmd` against the gRPC API of the service running via rkt.
 
-    ./bin/bootcmd profile list --endpoints 172.15.0.2:8081 --cacert examples/etc/bootcfg/ca.crt
+    ./bin/bootcmd profile list --endpoints 172.18.0.2:8081 --cacert examples/etc/bootcfg/ca.crt
 
 ## Dependencies
 

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -41,7 +41,7 @@ sudo bash -c 'cat > /etc/rkt/net.d/20-metal.conf << EOF
   "ipMasq": true,
   "ipam": {
     "type": "host-local",
-    "subnet": "172.15.0.0/16",
+    "subnet": "172.18.0.0/24",
     "routes" : [ { "dst" : "0.0.0.0/0" } ]
    }
 }
@@ -58,19 +58,19 @@ For development convenience, add `/etc/hosts` entries for nodes so they may be r
 
     # /etc/hosts
     ...
-    172.15.0.21 node1.example.com
-    172.15.0.22 node2.example.com
-    172.15.0.23 node3.example.com
+    172.18.0.21 node1.example.com
+    172.18.0.22 node2.example.com
+    172.18.0.23 node3.example.com
 
 ## Containers
 
 Run the latest `bootcfg` ACI with rkt and the `etcd` example.
 
-    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
+    sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
 
 or run the latest tagged release signed by the [CoreOS App Signing Key](https://coreos.com/security/app-signing-key/).
 
-    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd coreos.com/bootcfg:v0.4.1 -- -address=0.0.0.0:8080 -log-level=debug
+    sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd coreos.com/bootcfg:v0.4.1 -- -address=0.0.0.0:8080 -log-level=debug
 
 If you get an error about the IP assignment, stop old pods and run garbage collection.
 
@@ -78,9 +78,9 @@ If you get an error about the IP assignment, stop old pods and run garbage colle
 
 Take a look at the [etcd groups](../examples/groups/etcd) to get an idea of how machines are mapped to Profiles. Explore some endpoints exposed by the service, say for QEMU/KVM node1.
 
-* iPXE [http://172.15.0.2:8080/ipxe?mac=52:54:00:a1:9c:ae](http://172.15.0.2:8080/ipxe?mac=52:54:00:a1:9c:ae)
-* Ignition [http://172.15.0.2:8080/ignition?mac=52:54:00:a1:9c:ae](http://172.15.0.2:8080/ignition?mac=52:54:00:a1:9c:ae)
-* Metadata [http://172.15.0.2:8080/metadata?mac=52:54:00:a1:9c:ae](http://172.15.0.2:8080/metadata?mac=52:54:00:a1:9c:ae)
+* iPXE [http://172.18.0.2:8080/ipxe?mac=52:54:00:a1:9c:ae](http://172.18.0.2:8080/ipxe?mac=52:54:00:a1:9c:ae)
+* Ignition [http://172.18.0.2:8080/ignition?mac=52:54:00:a1:9c:ae](http://172.18.0.2:8080/ignition?mac=52:54:00:a1:9c:ae)
+* Metadata [http://172.18.0.2:8080/metadata?mac=52:54:00:a1:9c:ae](http://172.18.0.2:8080/metadata?mac=52:54:00:a1:9c:ae)
 
 ## Network
 
@@ -93,9 +93,9 @@ Trust the [CoreOS App Signing Key](https://coreos.com/security/app-signing-key/)
 
 Run the `coreos.com/dnsmasq` ACI with rkt.
 
-    sudo rkt run coreos.com/dnsmasq:v0.3.0 --net=metal0:IP=172.15.0.3 --mount volume=config,target=/etc/dnsmasq.conf --volume config,kind=host,source=$PWD/contrib/dnsmasq/metal0.conf
+    sudo rkt run coreos.com/dnsmasq:v0.3.0 --net=metal0:IP=172.18.0.3 --mount volume=config,target=/etc/dnsmasq.conf --volume config,kind=host,source=$PWD/contrib/dnsmasq/metal0.conf
 
-In this case, dnsmasq runs a DHCP server allocating IPs to VMs between 172.15.0.50 and 172.15.0.99, resolves `bootcfg.foo` to 172.15.0.2 (the IP where `bootcfg` runs), and points iPXE clients to `http://bootcfg.foo:8080/boot.ipxe`.
+In this case, dnsmasq runs a DHCP server allocating IPs to VMs between 172.18.0.50 and 172.18.0.99, resolves `bootcfg.foo` to 172.18.0.2 (the IP where `bootcfg` runs), and points iPXE clients to `http://bootcfg.foo:8080/boot.ipxe`.
 
 ## Client VMs
 

--- a/Documentation/grub.md
+++ b/Documentation/grub.md
@@ -23,7 +23,7 @@ On Fedora, add the `metal0` interface to the trusted zone in your firewall confi
 
 Run the `coreos.com/dnsmasq` ACI with rkt.
 
-    sudo rkt run coreos.com/dnsmasq:v0.3.0 --net=metal0:IP=172.15.0.3 -- -d -q --dhcp-range=172.15.0.50,172.15.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-match=set:efi-bc,option:client-arch,7 --dhcp-boot=tag:efi-bc,grub.efi --dhcp-userclass=set:grub,GRUB2 --dhcp-boot=tag:grub,"(http;bootcfg.foo:8080)/grub","172.15.0.2" --log-queries --log-dhcp --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:pxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://bootcfg.foo:8080/boot.ipxe --address=/bootcfg.foo/172.15.0.2
+    sudo rkt run coreos.com/dnsmasq:v0.3.0 --net=metal0:IP=172.18.0.3 -- -d -q --dhcp-range=172.18.0.50,172.18.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-match=set:efi-bc,option:client-arch,7 --dhcp-boot=tag:efi-bc,grub.efi --dhcp-userclass=set:grub,GRUB2 --dhcp-boot=tag:grub,"(http;bootcfg.foo:8080)/grub","172.18.0.2" --log-queries --log-dhcp --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:pxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://bootcfg.foo:8080/boot.ipxe --address=/bootcfg.foo/172.18.0.2
 
 ## Client VM
 

--- a/Documentation/network-setup.md
+++ b/Documentation/network-setup.md
@@ -39,7 +39,7 @@ Add a DNS entry (e.g. `bootcfg.foo`, `provisoner.mycompany-internal`) that resol
 If you deployed `bootcfg` to a known IP address (e.g. dedicated host, load balanced endpoint, Kubernetes NodePort) and use `dnsmasq`, a domain name to IPv4/IPv6 address mapping could be added to the `/etc/dnsmasq.conf`.
 
     # dnsmasq.conf
-    address=/bootcfg.foo/172.15.0.2
+    address=/bootcfg.foo/172.18.0.2
 
 ## iPXE
 

--- a/Documentation/torus.md
+++ b/Documentation/torus.md
@@ -27,11 +27,9 @@ Download the CoreOS image assets referenced in the target [profile](../examples/
 
 ## Containers
 
-Run the latest `bootcfg` ACI with rkt and the `torus` example.
+Use rkt or docker to start `bootcfg` and mount `torus` example. Create a network boot environment and power-on your machines. Revisit [bootcfg with rkt](getting-started-rkt.md) or [bootcfg with Docker](getting-started-docker.md) for help.
 
-    sudo rkt run --net=metal0:IP=172.15.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/torus quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
-
-Create a network boot environment and power-on your machines. Revisit [bootcfg with rkt](getting-started-rkt.md) or [bootcfg with Docker](getting-started-docker.md) for help. Client machines should network boot and provision themselves.
+Client machines should network boot and provision themselves.
 
 ## Verify
 

--- a/contrib/dnsmasq/README.md
+++ b/contrib/dnsmasq/README.md
@@ -28,10 +28,10 @@ Configuration arguments can be provided at the command line. Check the dnsmasq [
 
 | flag     | description | example |
 |----------|-------------|---------|
-| --dhcp-range | Enable DHCP, lease given range | `172.15,0.50,172.15.0.99`, `192.168.1.1,proxy,255.255.255.0` |
+| --dhcp-range | Enable DHCP, lease given range | `172.18,0.50,172.18.0.99`, `192.168.1.1,proxy,255.255.255.0` |
 | --dhcp-boot | DHCP next server option | `http://bootcfg.foo:8080/boot.ipxe` |
 | --enable-tftp | Enable serving from tftp-root over TFTP | NA |
-| --address | IP address for a domain name | /bootcfg.foo/172.15.0.2 |
+| --address | IP address for a domain name | /bootcfg.foo/172.18.0.2 |
 
 ## ACI
 
@@ -45,7 +45,7 @@ Run `dnsmasq.aci` with rkt to run DHCP/proxyDHCP/TFTP/DNS services.
 
 DHCP+TFTP+DNS on the `metal0` bridge:
 
-    sudo rkt --insecure-options=image run dnsmasq.aci --net=metal0 -- -d -q --dhcp-range=172.15.0.50,172.15.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:#ipxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://bootcfg.foo:8080/boot.ipxe --log-queries --log-dhcp --dhcp-option=3,172.15.0.1 --address=/bootcfg.foo/172.15.0.2
+    sudo rkt --insecure-options=image run dnsmasq.aci --net=metal0 -- -d -q --dhcp-range=172.18.0.50,172.18.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:#ipxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://bootcfg.foo:8080/boot.ipxe --log-queries --log-dhcp --dhcp-option=3,172.18.0.1 --address=/bootcfg.foo/172.18.0.2
 
 ## Docker
 

--- a/contrib/dnsmasq/metal0.conf
+++ b/contrib/dnsmasq/metal0.conf
@@ -1,11 +1,11 @@
 # dnsmasq.conf
 
 no-daemon
-dhcp-range=172.15.0.50,172.15.0.99
-dhcp-option=3,172.15.0.1
-dhcp-host=52:54:00:a1:9c:ae,172.15.0.21,1h
-dhcp-host=52:54:00:b2:2f:86,172.15.0.22,1h
-dhcp-host=52:54:00:c3:61:77,172.15.0.23,1h
+dhcp-range=172.18.0.50,172.18.0.99
+dhcp-option=3,172.18.0.1
+dhcp-host=52:54:00:a1:9c:ae,172.18.0.21,1h
+dhcp-host=52:54:00:b2:2f:86,172.18.0.22,1h
+dhcp-host=52:54:00:c3:61:77,172.18.0.23,1h
 
 enable-tftp
 tftp-root=/var/lib/tftpboot
@@ -17,8 +17,8 @@ dhcp-boot=tag:ipxe,http://bootcfg.foo:8080/boot.ipxe
 log-queries
 log-dhcp
 
-address=/bootcfg.foo/172.15.0.2
-address=/node1.example.com/172.15.0.21
-address=/node2.example.com/172.15.0.22
-address=/node3.example.com/172.15.0.23
-address=/cluster.example.com/172.15.0.21
+address=/bootcfg.foo/172.18.0.2
+address=/node1.example.com/172.18.0.21
+address=/node2.example.com/172.18.0.22
+address=/node3.example.com/172.18.0.23
+address=/cluster.example.com/172.18.0.21

--- a/examples/etc/bootcfg/README.md
+++ b/examples/etc/bootcfg/README.md
@@ -12,7 +12,7 @@ Navigate to the example directory which will be mounted as `/etc/bootcfg` in exa
 Set certificate subject alt names which should be used by exporting `SAN`. Use the DNS name or IP at which `bootcfg` is hosted.
 
     # for examples on metal0 or docker0 bridges
-    export SAN=IP.1:127.0.0.1,IP.2:172.15.0.2
+    export SAN=IP.1:127.0.0.1,IP.2:172.18.0.2
 
     # production example
     export SAN=DNS.1:bootcfg.example.com

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,11 +43,11 @@ Create QEMU/KVM VMs which are configured to boot from the network. The `scripts/
 Generate TLS certificates needed for a multi-node Kubernetes cluster. See the [examples](../examples/README.md#assets).
 
     $ ./scripts/tls/k8s-certgen -h
-    ./scripts/tls/k8s-certgen -h
     Usage: k8s-certgen
     Options:
       -d DEST     Destination for generated files (default: .examples/assets/tls)
-      -s SERVER   Reachable Server IP for kubeconfig (e.g. 172.15.0.21)
-      -m MASTERS  Master Node Names/Addresses in SAN format (e.g. IP.1=10.3.0.1,IP.2=172.15.0.21).
-      -w WORKERS  Worker Node Names/Addresses in SAN format (e.g. IP.1=172.15.0.22,IP.2=172.15.0.23)
-      -h          Show help.
+      -s SERVER   Reachable Server IP for kubeconfig (e.g. node1.example.com)
+      -m MASTERS  Controller Node Names/Addresses in SAN format (e.g. IP.1=10.3.0.1,DNS.1=node1.example.com)
+      -w WORKERS  Worker Node Names/Addresses in SAN format (e.g. DNS.1=node2.example.com,DNS.2=node3.example.com)
+      -h          Show help
+

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -75,7 +75,7 @@ function create {
   systemd-run --unit=dev-bootcfg \
     rkt run \
     --uuid-file-save=/tmp/bootcfg \
-    --net=metal0:IP=172.15.0.2 \
+    --net=metal0:IP=172.18.0.2 \
     --mount volume=config,target=/etc/bootcfg \
     --volume config,kind=host,source=$PWD/examples/etc/bootcfg,readOnly=true \
     --mount volume=data,target=/var/lib/bootcfg \
@@ -86,7 +86,7 @@ function create {
   systemd-run --unit=dev-dnsmasq \
     rkt run \
     --uuid-file-save=/tmp/dnsmasq \
-    --net=metal0:IP=172.15.0.3 \
+    --net=metal0:IP=172.18.0.3 \
     --mount volume=config,target=/etc/dnsmasq.conf \
     --volume config,kind=host,source=$DIR/../contrib/dnsmasq/metal0.conf \
     coreos.com/dnsmasq:v0.3.0

--- a/scripts/tls/k8s-certgen
+++ b/scripts/tls/k8s-certgen
@@ -4,9 +4,9 @@ USAGE="Usage: $(basename $0)
 Options:
   -d DEST     Destination for generated files (default: .examples/assets/tls)
   -s SERVER   Reachable Server IP for kubeconfig (e.g. node1.example.com)
-  -m MASTERS  Controller Node Names/Addresses in SAN format (e.g. IP.1=10.3.0.1,DNS.1=node1.example.com).
+  -m MASTERS  Controller Node Names/Addresses in SAN format (e.g. IP.1=10.3.0.1,DNS.1=node1.example.com)
   -w WORKERS  Worker Node Names/Addresses in SAN format (e.g. DNS.1=node2.example.com,DNS.2=node3.example.com)
-  -h          Show help.
+  -h          Show help
 "
 
 DEST="./examples/assets/tls"


### PR DESCRIPTION
* Change CIDR from 172.15.0.0/16, which isn't a reserved private range
* Use a smaller CIDR, /24 is sufficient

### Migration

If you have an old `metal0` bridge (`brctl show`) you should re-create it. Stop and cleanup any running pods.

```
sudo ./scripts/devnet destroy
sudo rkt gc --grace-period=0
```

Remove the old virtual bridge.

```
sudo rm /etc/rkt/net.d/20-metal.conf
sudo ip link set metal0 down
sudo  brctl delbr metal0
```

Update any `/etc/hosts` entries from `172.15.0.*` to `172.18.0.*`.

Follow [getting-started-rkt](https://github.com/coreos/coreos-baremetal/blob/master/Documentation/getting-started-rkt.md) to re-create metal0 on `172.18.0.0/16`. Copied here for ease.

```
sudo bash -c 'cat > /etc/rkt/net.d/20-metal.conf << EOF
{
  "name": "metal0",
  "type": "bridge",
  "bridge": "metal0",
  "isGateway": true,
  "ipMasq": true,
  "ipam": {
    "type": "host-local",
    "subnet": "172.18.0.0/24",
    "routes" : [ { "dst" : "0.0.0.0/0" } ]
   }
}
EOF'
```


Test that you can run:

```
sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/bootcfg --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/bootcfg/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/bootcfg:latest -- -address=0.0.0.0:8080 -log-level=debug
```

fyi @sym3tri @ericchiang @rithujohn191 @squat



