### PR TITLE
examples: Remove old kubelet pods by uuid-file

### DIFF
--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -50,12 +50,17 @@ systemd:
         Description=Kubelet via Hyperkube ACI
         Wants=flanneld.service
         [Service]
-        Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
+        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+          --volume=resolv,kind=host,source=/etc/resolv.conf \
+          --mount volume=resolv,target=/etc/resolv.conf \
+          --volume var-log,kind=host,source=/var/log \
+          --mount volume=var-log,target=/var/log"
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=-/usr/bin/rkt rm --uuid=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers={{.k8s_controller_endpoint}} \
           --kubeconfig=/etc/kubernetes/kubeconfig \
@@ -68,6 +73,7 @@ systemd:
           --minimum-container-ttl-duration=6m0s \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
+        ExecStop=-/usr/bin/rkt stop --uuid=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=10
         [Install]

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -41,12 +41,17 @@ systemd:
         Description=Kubelet via Hyperkube ACI
         Wants=flanneld.service
         [Service]
-        Environment="RKT_OPTS=--volume=resolv,kind=host,source=/etc/resolv.conf --mount volume=resolv,target=/etc/resolv.conf --volume var-log,kind=host,source=/var/log --mount volume=var-log,target=/var/log"
+        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+          --volume=resolv,kind=host,source=/etc/resolv.conf \
+          --mount volume=resolv,target=/etc/resolv.conf \
+          --volume var-log,kind=host,source=/var/log \
+          --mount volume=var-log,target=/var/log"
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=-/usr/bin/rkt rm --uuid=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers={{.k8s_controller_endpoint}} \
           --kubeconfig=/etc/kubernetes/kubeconfig \
@@ -58,6 +63,7 @@ systemd:
           --minimum-container-ttl-duration=6m0s \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
+        ExecStop=-/usr/bin/rkt stop --uuid=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=5
         [Install]

--- a/examples/ignition/k8s-controller.yaml
+++ b/examples/ignition/k8s-controller.yaml
@@ -65,13 +65,15 @@ systemd:
         After=k8s-assets.target
         [Service]
         Environment=KUBELET_VERSION=v1.4.6_coreos.0
-        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+          --volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log"
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
+        ExecStartPre=-/usr/bin/rkt rm --uuid=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers=http://127.0.0.1:8080 \
           --register-schedulable=true \
@@ -82,6 +84,7 @@ systemd:
           --hostname-override={{.domain_name}} \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
+        ExecStop=-/usr/bin/rkt stop --uuid=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=10
         [Install]

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -59,12 +59,14 @@ systemd:
         After=k8s-assets.target
         [Service]
         Environment=KUBELET_VERSION=v1.4.6_coreos.0
-        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+          --volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log"
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
+        ExecStartPre=-/usr/bin/rkt rm --uuid=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers={{.k8s_controller_endpoint}} \
           --register-node=true \
@@ -78,6 +80,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
           --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
+        ExecStop=-/usr/bin/rkt stop --uuid=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=10
         [Install]

--- a/examples/ignition/rktnetes-controller.yaml
+++ b/examples/ignition/rktnetes-controller.yaml
@@ -65,7 +65,8 @@ systemd:
         After=k8s-assets.target
         [Service]
         Environment=KUBELET_VERSION=v1.4.6_coreos.0
-        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+          --volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
           --volume rkt,kind=host,source=/opt/bin/host-rkt \
           --mount volume=rkt,target=/usr/bin/rkt \
@@ -78,6 +79,7 @@ systemd:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
+        ExecStartPre=-/usr/bin/rkt rm --uuid=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers=http://127.0.0.1:8080 \
           --register-schedulable=true \
@@ -91,6 +93,7 @@ systemd:
           --hostname-override={{.domain_name}} \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
+        ExecStop=-/usr/bin/rkt stop --uuid=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=10
         [Install]

--- a/examples/ignition/rktnetes-worker.yaml
+++ b/examples/ignition/rktnetes-worker.yaml
@@ -59,7 +59,8 @@ systemd:
         After=k8s-assets.target
         [Service]
         Environment=KUBELET_VERSION=v1.4.6_coreos.0
-        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
+        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+          --volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
           --volume rkt,kind=host,source=/opt/bin/host-rkt \
           --mount volume=rkt,target=/usr/bin/rkt \
@@ -70,6 +71,7 @@ systemd:
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log"
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+        ExecStartPre=-/usr/bin/rkt rm --uuid=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --api-servers={{.k8s_controller_endpoint}} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
@@ -86,6 +88,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
           --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
+        ExecStop=-/usr/bin/rkt stop --uuid=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=10
         [Install]


### PR DESCRIPTION
* Save the rkt pod uuid on start and remove pod resources (files, network) on restart, without waiting on gc