### PR TITLE
Documentation: Deprecate Pixiecore support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Latest
 
+* Deprecate Pixiecore support
 * Update Fuze and Ignition to v0.11.2
 
 ## v0.4.2 (2016-12-7)

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -61,29 +61,6 @@ Finds the profile for the machine and renders the network boot config as a GRUB 
     initrdefi "(http;bootcfg.foo:8080)/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"
     }
 
-## Pixiecore
-
-Finds the profile matching the machine and renders the network boot config as JSON to implement the [Pixiecore API](https://github.com/danderson/pixiecore/blob/master/README.api.md). Currently, Pixiecore only provides the machine's MAC address for matching.
-
-    GET http://bootcfg.foo/pixiecore/v1/boot/:MAC
-
-**URL Parameters**
-
-| Name | Type   | Description |
-|------|--------|-------------|
-| mac  | string | MAC address |
-
-**Response**
-
-    {
-      "kernel":"/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
-      "initrd":["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
-      "cmdline":{
-        "cloud-config-url":"http://bootcfg.foo/cloud?mac=ADDRESS",
-        "coreos.autologin":""
-      }
-    }
-
 ## Cloud Config
 
 Finds the profile matching the machine and renders the corresponding Cloud-Config with group metadata, selectors, and query params.
@@ -192,7 +169,6 @@ OpenPGPG signature endpoints serve detached binary and ASCII armored signatures 
 | Endpoint   | Signature Endpoint | ASCII Signature Endpoint |
 |------------|--------------------|-------------------------|
 | iPXE       | `http://bootcfg.foo/ipxe.sig` | `http://bootcfg.foo/ipxe.asc` |
-| Pixiecore  | `http://bootcfg/pixiecore/v1/boot.sig/:MAC` | `http://bootcfg/pixiecore/v1/boot.asc/:MAC` |
 | GRUB2      | `http://bootcf.foo/grub.sig` | `http://bootcfg.foo/grub.asc` |
 | Ignition   | `http://bootcfg.foo/ignition.sig` | `http://bootcfg.foo/ignition.asc` |
 | Cloud-Config | `http://bootcfg.foo/cloud.sig` | `http://bootcfg.foo/cloud.asc` |

--- a/Documentation/bootcfg.md
+++ b/Documentation/bootcfg.md
@@ -3,7 +3,7 @@
 
 `bootcfg` is an HTTP and gRPC service that renders signed [Ignition configs](https://coreos.com/ignition/docs/latest/what-is-ignition.html), [cloud-configs](https://coreos.com/os/docs/latest/cloud-config.html), network boot configs, and metadata to machines to create CoreOS clusters. `bootcfg` maintains **Group** definitions which match machines to *profiles* based on labels (e.g. MAC address, UUID, stage, region). A **Profile** is a named set of config templates (e.g. iPXE, GRUB, Ignition config, Cloud-Config, generic configs). The aim is to use CoreOS Linux's early-boot capabilities to provision CoreOS machines.
 
-Network boot endpoints provide iPXE, GRUB, and [Pixiecore](https://github.com/google/netboot/tree/master/pixiecore) support. `bootcfg` can be deployed as a binary, as an [appc](https://github.com/appc/spec) container with rkt, or as a Docker container.
+Network boot endpoints provide PXE, iPXE, GRUB support. `bootcfg` can be deployed as a binary, as an [appc](https://github.com/appc/spec) container with rkt, or as a Docker container.
 
 ![Bootcfg Overview](img/overview.png)
 

--- a/Documentation/network-booting.md
+++ b/Documentation/network-booting.md
@@ -66,10 +66,6 @@ A TFTP server is used only to provide the `undionly.kpxe` boot program to older 
 
 CoreOS `bootcfg` can render signed iPXE scripts to machines based on their hardware attributes. Setup involves configuring your DHCP server to point iPXE clients to the `bootcfg` [iPXE endpoint](api.md#ipxe).
 
-#### Pixiecore
-
-[Pixiecore](https://github.com/danderson/pixiecore) is a newer service which implements a proxyDHCP server, TFTP server, and HTTP server all-in-one and calls through to an HTTP API. CoreOS `bootcfg` can serve Pixiecore JSON (optionally signed) based on the supplied MAC address, to implement the Pixiecore HTTP API.
-
 ## DHCP
 
 Many networks have DHCP services which are impractical to modify or disable. Company DHCP servers are governed by network admin policies and home/office networks often have routers running a DHCP service which cannot supply PXE options to PXE clients.

--- a/Documentation/openpgp.md
+++ b/Documentation/openpgp.md
@@ -10,7 +10,6 @@ Here are example signature endpoints without their query parameters.
 | Endpoint   | Signature Endpoint | ASCII Signature Endpoint |
 |------------|--------------------|-------------------------|
 | iPXE       | `http://bootcfg.foo/ipxe.sig` | `http://bootcfg.foo/ipxe.asc` |
-| Pixiecore  | `http://bootcfg/pixiecore/v1/boot.sig/:MAC` | `http://bootcfg/pixiecore/v1/boot.asc/:MAC` |
 | GRUB2      | `http://bootcf.foo/grub.sig` | `http://bootcfg.foo/grub.asc` |
 | Ignition   | `http://bootcfg.foo/ignition.sig` | `http://bootcfg.foo/ignition.asc` |
 | Cloud-Config | `http://bootcfg.foo/cloud.sig` | `http://bootcfg.foo/cloud.asc` |

--- a/bootcfg/http/pixiecore.go
+++ b/bootcfg/http/pixiecore.go
@@ -13,7 +13,7 @@ import (
 
 // pixiecoreHandler returns a handler that renders the boot config JSON for
 // the requester, to implement the Pixiecore API specification.
-// https://github.com/danderson/pixiecore/blob/master/README.api.md
+// DEPRECATED
 func (s *Server) pixiecoreHandler(core server.Server) ContextHandler {
 	fn := func(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 		// pixiecore only provides a MAC address label


### PR DESCRIPTION
* coreos-baremetal must support production Tectonic customers on bare-metal
* Focus on real-world, varied network environments and flexibility
* iPXE provides better hardware introspection than being limited to MAC
* Matching must extend beyond hardware identifiers
* ISC DHCP and dnsmasq provides production DHCP service
* If we desire all-in-one ease, it will be accomplished by packaging
* Drop Pixiecore (all-in-one binary) from the setups we can support or recommend
    * Code remains so anyone who was using it isn't taken by surprise and there are no hard feelings :)
