### PR TITLE
(maybe) examples: Use the kube-addon-manager on static clusters

### DIFF
--- a/examples/ignition/k8s-controller.yaml
+++ b/examples/ignition/k8s-controller.yaml
@@ -100,16 +100,6 @@ systemd:
         RestartSec=10
         [Install]
         WantedBy=multi-user.target
-    - name: k8s-addons.service
-      enable: true
-      contents: |
-        [Unit]
-        Description=Kubernetes Addons
-        [Service]
-        Type=oneshot
-        ExecStart=/opt/k8s-addons
-        [Install]
-        WantedBy=multi-user.target
     {{ if eq .container_runtime "rkt" }}
     - name: rkt-api.service
       enable: true
@@ -350,7 +340,37 @@ storage:
                   port: 10251
                 initialDelaySeconds: 15
                 timeoutSeconds: 15
-    - path: /srv/kubernetes/manifests/kube-dns-rc.yaml
+    - path: /etc/kubernetes/manifests/kube-addon-manager.yaml
+      filesystem: root
+      contents:
+        inline: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: kube-addon-manager
+            namespace: kube-system
+          spec:
+            hostNetwork: true
+            containers:
+            - name: kube-addon-manager
+              image: gcr.io/google-containers/kube-addon-manager:v5.1
+              command:
+              - /bin/bash
+              - -c
+              - /opt/kube-addons.sh
+              resources:
+                requests:
+                  cpu: 5m
+                  memory: 50Mi
+              volumeMounts:
+              - name: addons
+                mountPath: /etc/kubernetes/
+                readOnly: true
+            volumes:
+            - name: addons
+              hostPath:
+                path: /etc/kubernetes/
+    - path: /etc/kubernetes/addons/kube-dns-rc.yaml
       filesystem: root
       contents:
         inline: |
@@ -454,7 +474,7 @@ storage:
                   - containerPort: 8080
                     protocol: TCP
                 dnsPolicy: Default
-    - path: /srv/kubernetes/manifests/kube-dns-svc.yaml
+    - path: /etc/kubernetes/addons/kube-dns-svc.yaml
       filesystem: root
       contents:
         inline: |
@@ -478,7 +498,7 @@ storage:
             - name: dns-tcp
               port: 53
               protocol: TCP
-    - path: /srv/kubernetes/manifests/heapster-deployment.yaml
+    - path: /etc/kubernetes/addons/heapster-deployment.yaml
       filesystem: root
       contents:
         inline: |
@@ -556,7 +576,7 @@ storage:
                       - --container=heapster
                       - --poll-period=300000
                       - --estimator=exponential
-    - path: /srv/kubernetes/manifests/heapster-svc.yaml
+    - path: /etc/kubernetes/addons/heapster-svc.yaml
       filesystem: root
       contents:
         inline: |
@@ -574,7 +594,7 @@ storage:
                 targetPort: 8082
             selector: 
               k8s-app: heapster
-    - path: /srv/kubernetes/manifests/kube-dashboard-rc.yaml
+    - path: /etc/kubernetes/addons/kube-dashboard-rc.yaml
       filesystem: root
       contents:
         inline: |
@@ -619,7 +639,7 @@ storage:
                       port: 9090
                     initialDelaySeconds: 30
                     timeoutSeconds: 30
-    - path: /srv/kubernetes/manifests/kube-dashboard-svc.yaml
+    - path: /etc/kubernetes/addons/kube-dashboard-svc.yaml
       filesystem: root
       contents:
         inline: |
@@ -683,26 +703,6 @@ storage:
           # https://github.com/coreos/rkt/issues/2878
           exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
     {{ end }}
-    - path: /opt/k8s-addons
-      filesystem: root
-      mode: 0544
-      contents:
-        inline: |
-          #!/bin/bash -ex
-          echo "Waiting for Kubernetes API..."
-          until curl --silent "http://127.0.0.1:8080/version"
-          do
-            sleep 5
-          done
-          echo "K8S: DNS addon"
-          curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.yaml)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
-          curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dns-svc.yaml)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
-          echo "K8S: Heapster addon"
-          curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-deployment.yaml)" "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
-          curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/heapster-svc.yaml)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
-          echo "K8S: Dashboard addon"
-          curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-rc.yaml)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers" > /dev/null
-          curl --silent -H "Content-Type: application/yaml" -XPOST -d"$(cat /srv/kubernetes/manifests/kube-dashboard-svc.yaml)" "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services" > /dev/null
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:


### PR DESCRIPTION
* Use kube-addon-manager to create Kubernetes addons on static Kubernetes clusters, rather than a systemd unit and curl script

Background:

The on-host kubelet, configured with `--pod-manifest-path=/etc/kubernetes/manifests`, creates and syncs pod manifests onto the *host* node. The `kube-addon-manager` pod ensures `/etc/kubernetes/addons` manifests are created on the *cluster* (such as kube-dns and heapster). The `kube-addon-manager` can be added to the controller pod-manifest-path. One will run on each controller (though one per cluster would suffice).

Pros:

The `kube-addon-manager` is a bit better than the curl scripts it replaces. It periodically syncs and retries and uses `kubectl` to create different resources. It elevates manifest creation failures from a journal log on the host to something visible in kubectl logs.

Cons:

However, it does add yet another gcr.io image to fetch (EDIT: that image is huge, 255MB are you kidding me!), and its not much more than a shell script itself.

Note: This is only even plausible on static Kubernetes clusters. In self-hosted clusters, the idea is to break away from pod manifests on the host and kube-addon-manager is not a good fit.

@pbx0 thoughts? I'm thinking maybe we fork the addon-manager and make it tiny or leave the curl scripts we had.
