### PR TITLE
examples: Upgrade self-hosted Kubernetes to v1.5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 #### Examples
 
 * Upgrade Kubernetes v1.4.7 (static) example clusters
-* Upgrade Kubernetes v1.4.7 (self-hosted) example cluster
+* Upgrade Kubernetes v1.5.1 (self-hosted) example cluster
 * Combine rktnetes Ignition into Kubernetes static cluster
 
 ## v0.4.2 (2016-12-7)

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,7 +1,7 @@
 
 # Self-Hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.4.7 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.5.1 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -12,10 +12,12 @@ Ensure that you've gone through the [bootcfg with rkt](getting-started-rkt.md) o
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Build and install the [fork of bootkube](https://github.com/dghubble/bootkube), which supports DNS names.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases/tag/v0.3.1) v0.3.1 and add it somewhere on your PATH.
 
-    $ bootkube version
-    Version: 4a4ae6e78a59258b528f7de57db8d5cf5786a8a5
+    $ wget https://github.com/kubernetes-incubator/bootkube/releases/download/v0.3.1/bootkube.tar.gz
+    $ tar xzf bootkube.tar.gz
+    $ ./bin/linux/bootkube version
+    Version: v0.3.1
 
 ## Examples
 

--- a/examples/groups/bootkube-install/node1.json
+++ b/examples/groups/bootkube-install/node1.json
@@ -10,7 +10,6 @@
     "domain_name": "node1.example.com",
     "etcd_initial_cluster": "node1=http://node1.example.com:2380",
     "etcd_name": "node1",
-    "k8s_controller_endpoint": "https://node1.example.com:443",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://node1.example.com:2379",
     "k8s_pod_network": "10.2.0.0/16",

--- a/examples/groups/bootkube-install/node2.json
+++ b/examples/groups/bootkube-install/node2.json
@@ -9,7 +9,6 @@
   "metadata": {
     "domain_name": "node2.example.com",
     "etcd_initial_cluster": "node1=http://node1.example.com:2380",
-    "k8s_controller_endpoint": "https://node1.example.com:443",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",

--- a/examples/groups/bootkube-install/node3.json
+++ b/examples/groups/bootkube-install/node3.json
@@ -9,7 +9,6 @@
   "metadata": {
     "domain_name": "node3.example.com",
     "etcd_initial_cluster": "node1=http://node1.example.com:2380",
-    "k8s_controller_endpoint": "https://node1.example.com:443",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",

--- a/examples/groups/bootkube/node1.json
+++ b/examples/groups/bootkube/node1.json
@@ -9,7 +9,6 @@
     "domain_name": "node1.example.com",
     "etcd_initial_cluster": "node1=http://node1.example.com:2380",
     "etcd_name": "node1",
-    "k8s_controller_endpoint": "https://node1.example.com:443",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_etcd_endpoints": "http://node1.example.com:2379",
     "k8s_pod_network": "10.2.0.0/16",

--- a/examples/groups/bootkube/node2.json
+++ b/examples/groups/bootkube/node2.json
@@ -8,7 +8,6 @@
   "metadata": {
     "domain_name": "node2.example.com",
     "etcd_initial_cluster": "node1=http://node1.example.com:2380",
-    "k8s_controller_endpoint": "https://node1.example.com:443",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",

--- a/examples/groups/bootkube/node3.json
+++ b/examples/groups/bootkube/node3.json
@@ -8,7 +8,6 @@
   "metadata": {
     "domain_name": "node3.example.com",
     "etcd_initial_cluster": "node1=http://node1.example.com:2380",
-    "k8s_controller_endpoint": "https://node1.example.com:443",
     "k8s_dns_service_ip": "10.3.0.10",
     "k8s_pod_network": "10.2.0.0/16",
     "k8s_service_ip_range": "10.3.0.0/24",

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -62,8 +62,8 @@ systemd:
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --api-servers={{.k8s_controller_endpoint}} \
           --kubeconfig=/etc/kubernetes/kubeconfig \
+          --require-kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention \
           --pod-manifest-path=/etc/kubernetes/manifests \
@@ -108,7 +108,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.4.7_coreos.0
+          KUBELET_VERSION=v1.5.1_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -133,7 +133,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.2.6}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.3.1}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/home/core/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -53,8 +53,8 @@ systemd:
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --api-servers={{.k8s_controller_endpoint}} \
           --kubeconfig=/etc/kubernetes/kubeconfig \
+          --require-kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention \
           --pod-manifest-path=/etc/kubernetes/manifests \
@@ -92,7 +92,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.4.7_coreos.0
+          KUBELET_VERSION=v1.5.1_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644


### PR DESCRIPTION
* Update bootkube version to stop requiring the forked binary; bootkube now allows DNS names
* https://github.com/kubernetes-incubator/bootkube/pull/151

cc @aaronlevy 