### PR TITLE
scripts: Add virt-install flag so reboots work

### DIFF
--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -42,7 +42,7 @@ function usage {
   echo -e "\tdestroy\t\tdestroy the QEMU/KVM nodes"
 }
 
-COMMON_VIRT_OPTS="--memory=1024 --vcpus=1 --pxe --disk pool=default,size=6 --os-type=linux --os-variant=generic --noautoconsole"
+COMMON_VIRT_OPTS="--memory=1024 --vcpus=1 --pxe --disk pool=default,size=6 --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve"
 
 function create_docker {
   virt-install --name $NODE1_NAME --network=bridge:docker0,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=hd,network


### PR DESCRIPTION
* virt-install created VMs which reboot themselves should actually reboot in order to mirror real machines

cc @ericchiang @rithujohn191 this should improve our lives